### PR TITLE
Fix DynamoDB compatibility issues in Pretender implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,28 +147,6 @@ Database setup follows this pattern:
    - Individual changesets: `liquibase/db-001.xml`, `liquibase/db-002.xml`, etc.
 4. **DAOs**: Use JDBI's SqlObject pattern with interfaces
 
-### Metrics
-
-The project uses codehead-metrics with declarative metrics via AspectJ:
-
-1. **Declarative Metrics**: Annotate methods with `@Metrics`
-2. **AspectJ Weaving**: Build file must include AspectJ post-compile weaving plugin
-3. **Automatic Tags**: All metrics include `host`, `stage`, `endpoint`, and `status` tags
-4. **Request Filters**: `MetricTagsResource` adds request/response context to metrics
-
-When adding metrics to a module:
-```kotlin
-// In build.gradle.kts
-plugins {
-    id("io.freefair.aspectj.post-compile-weaving") version "9.1.0"
-}
-
-dependencies {
-    implementation(libs.codehead.metrics.declarative)
-    aspect(libs.codehead.metrics.declarative)
-}
-```
-
 ### Testing Patterns
 
 1. **Unit Tests**: Use Mockito with `@ExtendWith(MockitoExtension.class)`
@@ -205,7 +183,7 @@ Standard Maven structure:
 
 Package naming convention:
 ```
-com.codeheadsystems.<module>.<layer>
+io.github.pretenderdb.<module>.<layer>
 ```
 
 Layers: `component`, `module`, `dao`, `manager`, `resource`, `converter`, `model`, `exception`

--- a/pretender-integ/src/test/java/io/github/pretenderdb/integ/BatchOperationsIntegrationTest.java
+++ b/pretender-integ/src/test/java/io/github/pretenderdb/integ/BatchOperationsIntegrationTest.java
@@ -1,0 +1,441 @@
+package io.github.pretenderdb.integ;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.BatchGetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.PutRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.WriteRequest;
+
+/**
+ * Integration test that validates batch operations work identically
+ * across DynamoDB Local and Pretender implementations.
+ */
+class BatchOperationsIntegrationTest {
+
+  private static final Logger log = LoggerFactory.getLogger(BatchOperationsIntegrationTest.class);
+  private static final String TABLE_NAME = "BatchTestTable";
+
+  static Stream<DynamoDbProvider> dynamoDbProviders() {
+    return Stream.of(
+        new DynamoDbLocalProvider(),
+        new PretenderPostgresProvider(),
+        new PretenderHsqldbProvider()
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testBatchWriteItemWithMultiplePuts(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing BATCH WRITE ITEM (puts) with: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Create batch write request with 10 items
+      List<WriteRequest> writeRequests = new ArrayList<>();
+      for (int i = 1; i <= 10; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("id", AttributeValue.builder().s("batch-item-" + i).build());
+        item.put("value", AttributeValue.builder().n(String.valueOf(i * 100)).build());
+        item.put("description", AttributeValue.builder().s("Batch item " + i).build());
+
+        writeRequests.add(WriteRequest.builder()
+            .putRequest(PutRequest.builder().item(item).build())
+            .build());
+      }
+
+      Map<String, List<WriteRequest>> requestItems = new HashMap<>();
+      requestItems.put(TABLE_NAME, writeRequests);
+
+      BatchWriteItemResponse response = client.batchWriteItem(BatchWriteItemRequest.builder()
+          .requestItems(requestItems)
+          .build());
+
+      // Verify no unprocessed items
+      assertThat(response.unprocessedItems()).isEmpty();
+
+      // Verify items were written by batch getting them
+      List<Map<String, AttributeValue>> keys = new ArrayList<>();
+      for (int i = 1; i <= 10; i++) {
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("id", AttributeValue.builder().s("batch-item-" + i).build());
+        keys.add(key);
+      }
+
+      Map<String, KeysAndAttributes> getRequestItems = new HashMap<>();
+      getRequestItems.put(TABLE_NAME, KeysAndAttributes.builder().keys(keys).build());
+
+      BatchGetItemResponse getResponse = client.batchGetItem(BatchGetItemRequest.builder()
+          .requestItems(getRequestItems)
+          .build());
+
+      assertThat(getResponse.responses()).containsKey(TABLE_NAME);
+      assertThat(getResponse.responses().get(TABLE_NAME)).hasSize(10);
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ BATCH WRITE ITEM (puts) test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testBatchGetItemWithMultipleKeys(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing BATCH GET ITEM with: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // First, write some items
+      List<WriteRequest> writeRequests = new ArrayList<>();
+      for (int i = 1; i <= 15; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("id", AttributeValue.builder().s("item-" + i).build());
+        item.put("data", AttributeValue.builder().s("Data for item " + i).build());
+
+        writeRequests.add(WriteRequest.builder()
+            .putRequest(PutRequest.builder().item(item).build())
+            .build());
+      }
+
+      Map<String, List<WriteRequest>> writeRequestItems = new HashMap<>();
+      writeRequestItems.put(TABLE_NAME, writeRequests);
+
+      client.batchWriteItem(BatchWriteItemRequest.builder()
+          .requestItems(writeRequestItems)
+          .build());
+
+      // Now batch get specific items
+      List<Map<String, AttributeValue>> keys = new ArrayList<>();
+      for (int i : new int[]{2, 5, 7, 11, 14}) {
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("id", AttributeValue.builder().s("item-" + i).build());
+        keys.add(key);
+      }
+
+      Map<String, KeysAndAttributes> requestItems = new HashMap<>();
+      requestItems.put(TABLE_NAME, KeysAndAttributes.builder().keys(keys).build());
+
+      BatchGetItemResponse response = client.batchGetItem(BatchGetItemRequest.builder()
+          .requestItems(requestItems)
+          .build());
+
+      // Verify we got exactly 5 items
+      assertThat(response.responses()).containsKey(TABLE_NAME);
+      assertThat(response.responses().get(TABLE_NAME)).hasSize(5);
+      assertThat(response.unprocessedKeys()).isEmpty();
+
+      // Verify the correct items were returned
+      List<String> returnedIds = response.responses().get(TABLE_NAME).stream()
+          .map(item -> item.get("id").s())
+          .sorted()
+          .toList();
+      assertThat(returnedIds).containsExactly("item-11", "item-14", "item-2", "item-5", "item-7");
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ BATCH GET ITEM test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testBatchWriteItemWithDeletes(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing BATCH WRITE ITEM (deletes) with: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // First, write some items
+      List<WriteRequest> writeRequests = new ArrayList<>();
+      for (int i = 1; i <= 10; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("id", AttributeValue.builder().s("delete-item-" + i).build());
+        item.put("status", AttributeValue.builder().s("active").build());
+
+        writeRequests.add(WriteRequest.builder()
+            .putRequest(PutRequest.builder().item(item).build())
+            .build());
+      }
+
+      Map<String, List<WriteRequest>> putRequestItems = new HashMap<>();
+      putRequestItems.put(TABLE_NAME, writeRequests);
+
+      client.batchWriteItem(BatchWriteItemRequest.builder()
+          .requestItems(putRequestItems)
+          .build());
+
+      // Now batch delete some items
+      List<WriteRequest> deleteRequests = new ArrayList<>();
+      for (int i : new int[]{2, 4, 6, 8}) {
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("id", AttributeValue.builder().s("delete-item-" + i).build());
+
+        deleteRequests.add(WriteRequest.builder()
+            .deleteRequest(DeleteRequest.builder().key(key).build())
+            .build());
+      }
+
+      Map<String, List<WriteRequest>> deleteRequestItems = new HashMap<>();
+      deleteRequestItems.put(TABLE_NAME, deleteRequests);
+
+      BatchWriteItemResponse deleteResponse = client.batchWriteItem(BatchWriteItemRequest.builder()
+          .requestItems(deleteRequestItems)
+          .build());
+
+      assertThat(deleteResponse.unprocessedItems()).isEmpty();
+
+      // Verify remaining items (should have 6 items left: 1, 3, 5, 7, 9, 10)
+      List<Map<String, AttributeValue>> allKeys = new ArrayList<>();
+      for (int i = 1; i <= 10; i++) {
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("id", AttributeValue.builder().s("delete-item-" + i).build());
+        allKeys.add(key);
+      }
+
+      Map<String, KeysAndAttributes> getRequestItems = new HashMap<>();
+      getRequestItems.put(TABLE_NAME, KeysAndAttributes.builder().keys(allKeys).build());
+
+      BatchGetItemResponse getResponse = client.batchGetItem(BatchGetItemRequest.builder()
+          .requestItems(getRequestItems)
+          .build());
+
+      // Should only get 6 items back (the ones not deleted)
+      assertThat(getResponse.responses().get(TABLE_NAME)).hasSize(6);
+
+      List<String> remainingIds = getResponse.responses().get(TABLE_NAME).stream()
+          .map(item -> item.get("id").s())
+          .sorted()
+          .toList();
+      assertThat(remainingIds).containsExactly(
+          "delete-item-1", "delete-item-10", "delete-item-3",
+          "delete-item-5", "delete-item-7", "delete-item-9"
+      );
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ BATCH WRITE ITEM (deletes) test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testBatchWriteItemWithMixedPutsAndDeletes(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing BATCH WRITE ITEM (mixed puts/deletes) with: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Write initial items
+      List<WriteRequest> initialWrites = new ArrayList<>();
+      for (int i = 1; i <= 5; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("id", AttributeValue.builder().s("mixed-item-" + i).build());
+        item.put("version", AttributeValue.builder().n("1").build());
+
+        initialWrites.add(WriteRequest.builder()
+            .putRequest(PutRequest.builder().item(item).build())
+            .build());
+      }
+
+      Map<String, List<WriteRequest>> initialRequestItems = new HashMap<>();
+      initialRequestItems.put(TABLE_NAME, initialWrites);
+
+      client.batchWriteItem(BatchWriteItemRequest.builder()
+          .requestItems(initialRequestItems)
+          .build());
+
+      // Mix of puts and deletes in one batch
+      List<WriteRequest> mixedRequests = new ArrayList<>();
+
+      // Add new items (6-8)
+      for (int i = 6; i <= 8; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("id", AttributeValue.builder().s("mixed-item-" + i).build());
+        item.put("version", AttributeValue.builder().n("1").build());
+
+        mixedRequests.add(WriteRequest.builder()
+            .putRequest(PutRequest.builder().item(item).build())
+            .build());
+      }
+
+      // Delete items (2, 4)
+      for (int i : new int[]{2, 4}) {
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("id", AttributeValue.builder().s("mixed-item-" + i).build());
+
+        mixedRequests.add(WriteRequest.builder()
+            .deleteRequest(DeleteRequest.builder().key(key).build())
+            .build());
+      }
+
+      Map<String, List<WriteRequest>> mixedRequestItems = new HashMap<>();
+      mixedRequestItems.put(TABLE_NAME, mixedRequests);
+
+      BatchWriteItemResponse response = client.batchWriteItem(BatchWriteItemRequest.builder()
+          .requestItems(mixedRequestItems)
+          .build());
+
+      assertThat(response.unprocessedItems()).isEmpty();
+
+      // Verify final state: should have items 1, 3, 5, 6, 7, 8 (6 total)
+      List<Map<String, AttributeValue>> allKeys = new ArrayList<>();
+      for (int i = 1; i <= 8; i++) {
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("id", AttributeValue.builder().s("mixed-item-" + i).build());
+        allKeys.add(key);
+      }
+
+      Map<String, KeysAndAttributes> getRequestItems = new HashMap<>();
+      getRequestItems.put(TABLE_NAME, KeysAndAttributes.builder().keys(allKeys).build());
+
+      BatchGetItemResponse getResponse = client.batchGetItem(BatchGetItemRequest.builder()
+          .requestItems(getRequestItems)
+          .build());
+
+      assertThat(getResponse.responses().get(TABLE_NAME)).hasSize(6);
+
+      List<String> finalIds = getResponse.responses().get(TABLE_NAME).stream()
+          .map(item -> item.get("id").s())
+          .sorted()
+          .toList();
+      assertThat(finalIds).containsExactly(
+          "mixed-item-1", "mixed-item-3", "mixed-item-5",
+          "mixed-item-6", "mixed-item-7", "mixed-item-8"
+      );
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ BATCH WRITE ITEM (mixed) test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testBatchGetItemWithNonExistentKeys(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing BATCH GET ITEM with non-existent keys: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Write only 3 items
+      List<WriteRequest> writeRequests = new ArrayList<>();
+      for (int i : new int[]{1, 3, 5}) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("id", AttributeValue.builder().s("sparse-item-" + i).build());
+        item.put("data", AttributeValue.builder().s("Data " + i).build());
+
+        writeRequests.add(WriteRequest.builder()
+            .putRequest(PutRequest.builder().item(item).build())
+            .build());
+      }
+
+      Map<String, List<WriteRequest>> writeRequestItems = new HashMap<>();
+      writeRequestItems.put(TABLE_NAME, writeRequests);
+
+      client.batchWriteItem(BatchWriteItemRequest.builder()
+          .requestItems(writeRequestItems)
+          .build());
+
+      // Try to batch get items including non-existent ones
+      List<Map<String, AttributeValue>> keys = new ArrayList<>();
+      for (int i = 1; i <= 6; i++) {
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("id", AttributeValue.builder().s("sparse-item-" + i).build());
+        keys.add(key);
+      }
+
+      Map<String, KeysAndAttributes> requestItems = new HashMap<>();
+      requestItems.put(TABLE_NAME, KeysAndAttributes.builder().keys(keys).build());
+
+      BatchGetItemResponse response = client.batchGetItem(BatchGetItemRequest.builder()
+          .requestItems(requestItems)
+          .build());
+
+      // Should only get the 3 items that exist
+      assertThat(response.responses().get(TABLE_NAME)).hasSize(3);
+
+      List<String> returnedIds = response.responses().get(TABLE_NAME).stream()
+          .map(item -> item.get("id").s())
+          .sorted()
+          .toList();
+      assertThat(returnedIds).containsExactly("sparse-item-1", "sparse-item-3", "sparse-item-5");
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ BATCH GET ITEM with non-existent keys test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  private void createSimpleTable(DynamoDbClient client) {
+    CreateTableRequest request = CreateTableRequest.builder()
+        .tableName(TABLE_NAME)
+        .keySchema(
+            KeySchemaElement.builder()
+                .attributeName("id")
+                .keyType(KeyType.HASH)
+                .build()
+        )
+        .attributeDefinitions(
+            AttributeDefinition.builder()
+                .attributeName("id")
+                .attributeType(ScalarAttributeType.S)
+                .build()
+        )
+        .provisionedThroughput(ProvisionedThroughput.builder()
+            .readCapacityUnits(5L)
+            .writeCapacityUnits(5L)
+            .build())
+        .build();
+
+    client.createTable(request);
+  }
+}

--- a/pretender-integ/src/test/java/io/github/pretenderdb/integ/ConditionalOperationsIntegrationTest.java
+++ b/pretender-integ/src/test/java/io/github/pretenderdb/integ/ConditionalOperationsIntegrationTest.java
@@ -1,0 +1,427 @@
+package io.github.pretenderdb.integ;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.ReturnValue;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
+
+/**
+ * Integration test that validates conditional operations work identically
+ * across DynamoDB Local and Pretender implementations.
+ */
+class ConditionalOperationsIntegrationTest {
+
+  private static final Logger log = LoggerFactory.getLogger(ConditionalOperationsIntegrationTest.class);
+  private static final String TABLE_NAME = "ConditionalTestTable";
+
+  static Stream<DynamoDbProvider> dynamoDbProviders() {
+    return Stream.of(
+        new DynamoDbLocalProvider(),
+        new PretenderPostgresProvider(),
+        new PretenderHsqldbProvider()
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testPutItemWithAttributeNotExists(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing PUT ITEM with attribute_not_exists condition: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // First put should succeed (item doesn't exist)
+      Map<String, AttributeValue> item = new HashMap<>();
+      item.put("id", AttributeValue.builder().s("conditional-1").build());
+      item.put("value", AttributeValue.builder().n("100").build());
+
+      client.putItem(PutItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .item(item)
+          .conditionExpression("attribute_not_exists(id)")
+          .build());
+
+      // Verify item was created
+      GetItemResponse getResponse = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(Map.of("id", AttributeValue.builder().s("conditional-1").build()))
+          .build());
+
+      assertThat(getResponse.hasItem()).isTrue();
+
+      // Second put with same condition should fail (item now exists)
+      Map<String, AttributeValue> item2 = new HashMap<>();
+      item2.put("id", AttributeValue.builder().s("conditional-1").build());
+      item2.put("value", AttributeValue.builder().n("200").build());
+
+      assertThatThrownBy(() -> client.putItem(PutItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .item(item2)
+          .conditionExpression("attribute_not_exists(id)")
+          .build()))
+          .isInstanceOf(ConditionalCheckFailedException.class);
+
+      // Verify original item unchanged
+      GetItemResponse finalCheck = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(Map.of("id", AttributeValue.builder().s("conditional-1").build()))
+          .build());
+
+      assertThat(finalCheck.item()).containsEntry("value", AttributeValue.builder().n("100").build());
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ PUT ITEM with attribute_not_exists test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testUpdateItemWithConditionExpression(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing UPDATE ITEM with condition expression: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Create initial item
+      Map<String, AttributeValue> item = new HashMap<>();
+      item.put("id", AttributeValue.builder().s("update-cond-1").build());
+      item.put("version", AttributeValue.builder().n("1").build());
+      item.put("balance", AttributeValue.builder().n("1000").build());
+
+      client.putItem(PutItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .item(item)
+          .build());
+
+      // Update with correct version should succeed
+      Map<String, AttributeValue> key = new HashMap<>();
+      key.put("id", AttributeValue.builder().s("update-cond-1").build());
+
+      Map<String, AttributeValue> updateValues = new HashMap<>();
+      updateValues.put(":newBalance", AttributeValue.builder().n("900").build());
+      updateValues.put(":expectedVersion", AttributeValue.builder().n("1").build());
+      updateValues.put(":newVersion", AttributeValue.builder().n("2").build());
+
+      client.updateItem(UpdateItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key)
+          .updateExpression("SET balance = :newBalance, version = :newVersion")
+          .conditionExpression("version = :expectedVersion")
+          .expressionAttributeValues(updateValues)
+          .build());
+
+      // Verify update succeeded
+      GetItemResponse getResponse = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key)
+          .build());
+
+      assertThat(getResponse.item()).containsEntry("version", AttributeValue.builder().n("2").build());
+      assertThat(getResponse.item()).containsEntry("balance", AttributeValue.builder().n("900").build());
+
+      // Update with wrong version should fail
+      Map<String, AttributeValue> wrongVersionValues = new HashMap<>();
+      wrongVersionValues.put(":newBalance", AttributeValue.builder().n("800").build());
+      wrongVersionValues.put(":expectedVersion", AttributeValue.builder().n("1").build());  // wrong version
+      wrongVersionValues.put(":newVersion", AttributeValue.builder().n("3").build());
+
+      assertThatThrownBy(() -> client.updateItem(UpdateItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key)
+          .updateExpression("SET balance = :newBalance, version = :newVersion")
+          .conditionExpression("version = :expectedVersion")
+          .expressionAttributeValues(wrongVersionValues)
+          .build()))
+          .isInstanceOf(ConditionalCheckFailedException.class);
+
+      // Verify item unchanged
+      GetItemResponse finalCheck = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key)
+          .build());
+
+      assertThat(finalCheck.item()).containsEntry("version", AttributeValue.builder().n("2").build());
+      assertThat(finalCheck.item()).containsEntry("balance", AttributeValue.builder().n("900").build());
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ UPDATE ITEM with condition expression test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testDeleteItemWithCondition(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing DELETE ITEM with condition: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Create items
+      Map<String, AttributeValue> item1 = new HashMap<>();
+      item1.put("id", AttributeValue.builder().s("delete-cond-1").build());
+      item1.put("status", AttributeValue.builder().s("active").build());
+
+      Map<String, AttributeValue> item2 = new HashMap<>();
+      item2.put("id", AttributeValue.builder().s("delete-cond-2").build());
+      item2.put("status", AttributeValue.builder().s("inactive").build());
+
+      client.putItem(PutItemRequest.builder().tableName(TABLE_NAME).item(item1).build());
+      client.putItem(PutItemRequest.builder().tableName(TABLE_NAME).item(item2).build());
+
+      // Try to delete item with wrong condition (should fail)
+      Map<String, AttributeValue> key1 = new HashMap<>();
+      key1.put("id", AttributeValue.builder().s("delete-cond-1").build());
+
+      Map<String, AttributeValue> wrongConditionValues = new HashMap<>();
+      wrongConditionValues.put(":expectedStatus", AttributeValue.builder().s("inactive").build());
+
+      assertThatThrownBy(() -> client.deleteItem(DeleteItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key1)
+          .conditionExpression("#status = :expectedStatus")
+          .expressionAttributeNames(Map.of("#status", "status"))
+          .expressionAttributeValues(wrongConditionValues)
+          .build()))
+          .isInstanceOf(ConditionalCheckFailedException.class);
+
+      // Verify item still exists
+      GetItemResponse stillExists = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key1)
+          .build());
+
+      assertThat(stillExists.hasItem()).isTrue();
+
+      // Delete with correct condition (should succeed)
+      Map<String, AttributeValue> correctConditionValues = new HashMap<>();
+      correctConditionValues.put(":expectedStatus", AttributeValue.builder().s("active").build());
+
+      client.deleteItem(DeleteItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key1)
+          .conditionExpression("#status = :expectedStatus")
+          .expressionAttributeNames(Map.of("#status", "status"))
+          .expressionAttributeValues(correctConditionValues)
+          .returnValues(ReturnValue.ALL_OLD)
+          .build());
+
+      // Verify item deleted
+      GetItemResponse afterDelete = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key1)
+          .build());
+
+      assertThat(afterDelete.hasItem()).isFalse();
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ DELETE ITEM with condition test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testConditionWithComparisonOperators(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing conditions with comparison operators: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Create item
+      Map<String, AttributeValue> item = new HashMap<>();
+      item.put("id", AttributeValue.builder().s("comparison-test").build());
+      item.put("stock", AttributeValue.builder().n("50").build());
+      item.put("minStock", AttributeValue.builder().n("10").build());
+
+      client.putItem(PutItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .item(item)
+          .build());
+
+      // Update with >= condition (should succeed)
+      Map<String, AttributeValue> key = new HashMap<>();
+      key.put("id", AttributeValue.builder().s("comparison-test").build());
+
+      Map<String, AttributeValue> updateValues = new HashMap<>();
+      updateValues.put(":minRequired", AttributeValue.builder().n("30").build());
+      updateValues.put(":decrease", AttributeValue.builder().n("20").build());
+
+      client.updateItem(UpdateItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key)
+          .updateExpression("SET stock = stock - :decrease")
+          .conditionExpression("stock >= :minRequired")
+          .expressionAttributeValues(updateValues)
+          .build());
+
+      // Verify update
+      GetItemResponse afterUpdate = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key)
+          .build());
+
+      assertThat(afterUpdate.item()).containsEntry("stock", AttributeValue.builder().n("30").build());
+
+      // Try update with > condition that should fail
+      Map<String, AttributeValue> failValues = new HashMap<>();
+      failValues.put(":minRequired", AttributeValue.builder().n("30").build());  // stock is exactly 30
+      failValues.put(":decrease", AttributeValue.builder().n("10").build());
+
+      assertThatThrownBy(() -> client.updateItem(UpdateItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key)
+          .updateExpression("SET stock = stock - :decrease")
+          .conditionExpression("stock > :minRequired")  // > instead of >=
+          .expressionAttributeValues(failValues)
+          .build()))
+          .isInstanceOf(ConditionalCheckFailedException.class);
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ Conditions with comparison operators test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testConditionWithAttributeExists(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing condition with attribute_exists: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Create item with optional attribute
+      Map<String, AttributeValue> item = new HashMap<>();
+      item.put("id", AttributeValue.builder().s("exists-test").build());
+      item.put("email", AttributeValue.builder().s("test@example.com").build());
+
+      client.putItem(PutItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .item(item)
+          .build());
+
+      // Update only if email exists (should succeed)
+      Map<String, AttributeValue> key = new HashMap<>();
+      key.put("id", AttributeValue.builder().s("exists-test").build());
+
+      Map<String, AttributeValue> updateValues = new HashMap<>();
+      updateValues.put(":verified", AttributeValue.builder().bool(true).build());
+
+      client.updateItem(UpdateItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key)
+          .updateExpression("SET verified = :verified")
+          .conditionExpression("attribute_exists(email)")
+          .expressionAttributeValues(updateValues)
+          .build());
+
+      // Verify update
+      GetItemResponse result = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key)
+          .build());
+
+      assertThat(result.item()).containsEntry("verified", AttributeValue.builder().bool(true).build());
+
+      // Create item without email
+      Map<String, AttributeValue> item2 = new HashMap<>();
+      item2.put("id", AttributeValue.builder().s("exists-test-2").build());
+      item2.put("name", AttributeValue.builder().s("No Email User").build());
+
+      client.putItem(PutItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .item(item2)
+          .build());
+
+      // Try to update with email exists condition (should fail)
+      Map<String, AttributeValue> key2 = new HashMap<>();
+      key2.put("id", AttributeValue.builder().s("exists-test-2").build());
+
+      assertThatThrownBy(() -> client.updateItem(UpdateItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key2)
+          .updateExpression("SET verified = :verified")
+          .conditionExpression("attribute_exists(email)")
+          .expressionAttributeValues(updateValues)
+          .build()))
+          .isInstanceOf(ConditionalCheckFailedException.class);
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ Condition with attribute_exists test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  private void createSimpleTable(DynamoDbClient client) {
+    CreateTableRequest request = CreateTableRequest.builder()
+        .tableName(TABLE_NAME)
+        .keySchema(
+            KeySchemaElement.builder()
+                .attributeName("id")
+                .keyType(KeyType.HASH)
+                .build()
+        )
+        .attributeDefinitions(
+            AttributeDefinition.builder()
+                .attributeName("id")
+                .attributeType(ScalarAttributeType.S)
+                .build()
+        )
+        .provisionedThroughput(ProvisionedThroughput.builder()
+            .readCapacityUnits(5L)
+            .writeCapacityUnits(5L)
+            .build())
+        .build();
+
+    client.createTable(request);
+  }
+}

--- a/pretender-integ/src/test/java/io/github/pretenderdb/integ/DataTypesIntegrationTest.java
+++ b/pretender-integ/src/test/java/io/github/pretenderdb/integ/DataTypesIntegrationTest.java
@@ -1,0 +1,412 @@
+package io.github.pretenderdb.integ;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+
+/**
+ * Integration test that validates all DynamoDB data types work identically
+ * across DynamoDB Local and Pretender implementations.
+ */
+class DataTypesIntegrationTest {
+
+  private static final Logger log = LoggerFactory.getLogger(DataTypesIntegrationTest.class);
+  private static final String TABLE_NAME = "DataTypesTestTable";
+
+  static Stream<DynamoDbProvider> dynamoDbProviders() {
+    return Stream.of(
+        new DynamoDbLocalProvider(),
+        new PretenderPostgresProvider(),
+        new PretenderHsqldbProvider()
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testScalarDataTypes(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing scalar data types: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Create item with all scalar types
+      Map<String, AttributeValue> item = new HashMap<>();
+      item.put("id", AttributeValue.builder().s("scalar-test").build());
+      item.put("stringAttr", AttributeValue.builder().s("Hello World").build());
+      item.put("numberAttr", AttributeValue.builder().n("12345.67").build());
+      item.put("binaryAttr", AttributeValue.builder()
+          .b(SdkBytes.fromString("Binary data", StandardCharsets.UTF_8))
+          .build());
+      item.put("boolAttr", AttributeValue.builder().bool(true).build());
+      item.put("nullAttr", AttributeValue.builder().nul(true).build());
+
+      client.putItem(PutItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .item(item)
+          .build());
+
+      // Retrieve and verify
+      GetItemResponse response = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(Map.of("id", AttributeValue.builder().s("scalar-test").build()))
+          .build());
+
+      assertThat(response.hasItem()).isTrue();
+      assertThat(response.item().get("stringAttr").s()).isEqualTo("Hello World");
+      assertThat(response.item().get("numberAttr").n()).isEqualTo("12345.67");
+      assertThat(response.item().get("binaryAttr").b().asString(StandardCharsets.UTF_8))
+          .isEqualTo("Binary data");
+      assertThat(response.item().get("boolAttr").bool()).isTrue();
+      assertThat(response.item().get("nullAttr").nul()).isTrue();
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ Scalar data types test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testSetDataTypes(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing set data types (SS, NS, BS): {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Create item with all set types
+      Map<String, AttributeValue> item = new HashMap<>();
+      item.put("id", AttributeValue.builder().s("set-test").build());
+      item.put("stringSet", AttributeValue.builder()
+          .ss("apple", "banana", "cherry")
+          .build());
+      item.put("numberSet", AttributeValue.builder()
+          .ns("100", "200", "300")
+          .build());
+      item.put("binarySet", AttributeValue.builder()
+          .bs(
+              SdkBytes.fromString("data1", StandardCharsets.UTF_8),
+              SdkBytes.fromString("data2", StandardCharsets.UTF_8),
+              SdkBytes.fromString("data3", StandardCharsets.UTF_8)
+          )
+          .build());
+
+      client.putItem(PutItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .item(item)
+          .build());
+
+      // Retrieve and verify
+      GetItemResponse response = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(Map.of("id", AttributeValue.builder().s("set-test").build()))
+          .build());
+
+      assertThat(response.hasItem()).isTrue();
+      assertThat(response.item().get("stringSet").ss())
+          .containsExactlyInAnyOrder("apple", "banana", "cherry");
+      assertThat(response.item().get("numberSet").ns())
+          .containsExactlyInAnyOrder("100", "200", "300");
+      assertThat(response.item().get("binarySet").bs())
+          .hasSize(3);
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ Set data types test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testListDataType(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing list data type: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Create item with list containing mixed types
+      Map<String, AttributeValue> item = new HashMap<>();
+      item.put("id", AttributeValue.builder().s("list-test").build());
+      item.put("mixedList", AttributeValue.builder()
+          .l(
+              AttributeValue.builder().s("string element").build(),
+              AttributeValue.builder().n("42").build(),
+              AttributeValue.builder().bool(true).build(),
+              AttributeValue.builder().nul(true).build()
+          )
+          .build());
+      item.put("numberList", AttributeValue.builder()
+          .l(
+              AttributeValue.builder().n("1").build(),
+              AttributeValue.builder().n("2").build(),
+              AttributeValue.builder().n("3").build()
+          )
+          .build());
+
+      client.putItem(PutItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .item(item)
+          .build());
+
+      // Retrieve and verify
+      GetItemResponse response = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(Map.of("id", AttributeValue.builder().s("list-test").build()))
+          .build());
+
+      assertThat(response.hasItem()).isTrue();
+
+      List<AttributeValue> mixedList = response.item().get("mixedList").l();
+      assertThat(mixedList).hasSize(4);
+      assertThat(mixedList.get(0).s()).isEqualTo("string element");
+      assertThat(mixedList.get(1).n()).isEqualTo("42");
+      assertThat(mixedList.get(2).bool()).isTrue();
+      assertThat(mixedList.get(3).nul()).isTrue();
+
+      List<AttributeValue> numberList = response.item().get("numberList").l();
+      assertThat(numberList).hasSize(3);
+      assertThat(numberList.get(0).n()).isEqualTo("1");
+      assertThat(numberList.get(1).n()).isEqualTo("2");
+      assertThat(numberList.get(2).n()).isEqualTo("3");
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ List data type test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testMapDataType(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing map data type: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Create item with nested map
+      Map<String, AttributeValue> addressMap = new HashMap<>();
+      addressMap.put("street", AttributeValue.builder().s("123 Main St").build());
+      addressMap.put("city", AttributeValue.builder().s("Springfield").build());
+      addressMap.put("zipCode", AttributeValue.builder().s("12345").build());
+      addressMap.put("verified", AttributeValue.builder().bool(true).build());
+
+      Map<String, AttributeValue> item = new HashMap<>();
+      item.put("id", AttributeValue.builder().s("map-test").build());
+      item.put("name", AttributeValue.builder().s("John Doe").build());
+      item.put("address", AttributeValue.builder().m(addressMap).build());
+
+      client.putItem(PutItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .item(item)
+          .build());
+
+      // Retrieve and verify
+      GetItemResponse response = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(Map.of("id", AttributeValue.builder().s("map-test").build()))
+          .build());
+
+      assertThat(response.hasItem()).isTrue();
+
+      Map<String, AttributeValue> retrievedAddress = response.item().get("address").m();
+      assertThat(retrievedAddress.get("street").s()).isEqualTo("123 Main St");
+      assertThat(retrievedAddress.get("city").s()).isEqualTo("Springfield");
+      assertThat(retrievedAddress.get("zipCode").s()).isEqualTo("12345");
+      assertThat(retrievedAddress.get("verified").bool()).isTrue();
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ Map data type test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testNestedDocumentTypes(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing deeply nested document types: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Create complex nested structure
+      Map<String, AttributeValue> orderItem1 = new HashMap<>();
+      orderItem1.put("productId", AttributeValue.builder().s("prod-123").build());
+      orderItem1.put("quantity", AttributeValue.builder().n("2").build());
+      orderItem1.put("price", AttributeValue.builder().n("29.99").build());
+
+      Map<String, AttributeValue> orderItem2 = new HashMap<>();
+      orderItem2.put("productId", AttributeValue.builder().s("prod-456").build());
+      orderItem2.put("quantity", AttributeValue.builder().n("1").build());
+      orderItem2.put("price", AttributeValue.builder().n("49.99").build());
+
+      Map<String, AttributeValue> shippingAddress = new HashMap<>();
+      shippingAddress.put("street", AttributeValue.builder().s("456 Oak Ave").build());
+      shippingAddress.put("city", AttributeValue.builder().s("Portland").build());
+
+      Map<String, AttributeValue> customerInfo = new HashMap<>();
+      customerInfo.put("customerId", AttributeValue.builder().s("cust-789").build());
+      customerInfo.put("email", AttributeValue.builder().s("customer@example.com").build());
+      customerInfo.put("shippingAddress", AttributeValue.builder().m(shippingAddress).build());
+
+      Map<String, AttributeValue> item = new HashMap<>();
+      item.put("id", AttributeValue.builder().s("nested-test").build());
+      item.put("orderDate", AttributeValue.builder().s("2024-01-15").build());
+      item.put("customer", AttributeValue.builder().m(customerInfo).build());
+      item.put("items", AttributeValue.builder()
+          .l(
+              AttributeValue.builder().m(orderItem1).build(),
+              AttributeValue.builder().m(orderItem2).build()
+          )
+          .build());
+      item.put("tags", AttributeValue.builder().ss("express", "gift", "priority").build());
+
+      client.putItem(PutItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .item(item)
+          .build());
+
+      // Retrieve and verify
+      GetItemResponse response = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(Map.of("id", AttributeValue.builder().s("nested-test").build()))
+          .build());
+
+      assertThat(response.hasItem()).isTrue();
+
+      // Verify nested customer data
+      Map<String, AttributeValue> customer = response.item().get("customer").m();
+      assertThat(customer.get("customerId").s()).isEqualTo("cust-789");
+
+      Map<String, AttributeValue> address = customer.get("shippingAddress").m();
+      assertThat(address.get("city").s()).isEqualTo("Portland");
+
+      // Verify list of maps
+      List<AttributeValue> orderItems = response.item().get("items").l();
+      assertThat(orderItems).hasSize(2);
+      assertThat(orderItems.get(0).m().get("productId").s()).isEqualTo("prod-123");
+      assertThat(orderItems.get(1).m().get("quantity").n()).isEqualTo("1");
+
+      // Verify string set
+      assertThat(response.item().get("tags").ss())
+          .containsExactlyInAnyOrder("express", "gift", "priority");
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ Nested document types test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testEmptyAndNullValues(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing empty and null values: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Create item with NULL and empty containers
+      Map<String, AttributeValue> emptyMap = new HashMap<>();
+      Map<String, AttributeValue> item = new HashMap<>();
+      item.put("id", AttributeValue.builder().s("empty-test").build());
+      item.put("nullValue", AttributeValue.builder().nul(true).build());
+      item.put("emptyList", AttributeValue.builder().l(List.of()).build());
+      item.put("emptyMap", AttributeValue.builder().m(emptyMap).build());
+      item.put("presentValue", AttributeValue.builder().s("I exist").build());
+
+      client.putItem(PutItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .item(item)
+          .build());
+
+      // Retrieve and verify
+      GetItemResponse response = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(Map.of("id", AttributeValue.builder().s("empty-test").build()))
+          .build());
+
+      assertThat(response.hasItem()).isTrue();
+      assertThat(response.item().get("nullValue").nul()).isTrue();
+      assertThat(response.item().get("emptyList").l()).isEmpty();
+      assertThat(response.item().get("emptyMap").m()).isEmpty();
+      assertThat(response.item().get("presentValue").s()).isEqualTo("I exist");
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ Empty and null values test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  private void createSimpleTable(DynamoDbClient client) {
+    CreateTableRequest request = CreateTableRequest.builder()
+        .tableName(TABLE_NAME)
+        .keySchema(
+            KeySchemaElement.builder()
+                .attributeName("id")
+                .keyType(KeyType.HASH)
+                .build()
+        )
+        .attributeDefinitions(
+            AttributeDefinition.builder()
+                .attributeName("id")
+                .attributeType(ScalarAttributeType.S)
+                .build()
+        )
+        .provisionedThroughput(ProvisionedThroughput.builder()
+            .readCapacityUnits(5L)
+            .writeCapacityUnits(5L)
+            .build())
+        .build();
+
+    client.createTable(request);
+  }
+}

--- a/pretender-integ/src/test/java/io/github/pretenderdb/integ/EdgeCasesIntegrationTest.java
+++ b/pretender-integ/src/test/java/io/github/pretenderdb/integ/EdgeCasesIntegrationTest.java
@@ -1,0 +1,610 @@
+package io.github.pretenderdb.integ;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.ReturnValue;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
+
+/**
+ * Integration test that validates edge cases and validation behavior
+ * work identically across DynamoDB Local and Pretender implementations.
+ */
+class EdgeCasesIntegrationTest {
+
+  private static final Logger log = LoggerFactory.getLogger(EdgeCasesIntegrationTest.class);
+  private static final String TABLE_NAME = "EdgeCasesTestTable";
+
+  static Stream<DynamoDbProvider> dynamoDbProviders() {
+    return Stream.of(
+        new DynamoDbLocalProvider(),
+        new PretenderPostgresProvider(),
+        new PretenderHsqldbProvider()
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testGetItemNonExistentKey(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing GET ITEM with non-existent key: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Try to get item that doesn't exist
+      Map<String, AttributeValue> key = new HashMap<>();
+      key.put("id", AttributeValue.builder().s("does-not-exist").build());
+
+      GetItemResponse response = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key)
+          .build());
+
+      // Should return empty response (not throw exception)
+      assertThat(response.hasItem()).isFalse();
+      assertThat(response.item()).isEmpty();
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ GET ITEM with non-existent key test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testDeleteItemNonExistent(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing DELETE ITEM on non-existent item: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Delete item that doesn't exist - should succeed silently
+      Map<String, AttributeValue> key = new HashMap<>();
+      key.put("id", AttributeValue.builder().s("never-existed").build());
+
+      client.deleteItem(DeleteItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key)
+          .build());
+
+      // No exception should be thrown
+      assertThat(true).isTrue();
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ DELETE ITEM on non-existent item test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testPutItemOverwrite(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing PUT ITEM overwrite behavior: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Put initial item
+      Map<String, AttributeValue> item1 = new HashMap<>();
+      item1.put("id", AttributeValue.builder().s("overwrite-test").build());
+      item1.put("value", AttributeValue.builder().n("100").build());
+      item1.put("name", AttributeValue.builder().s("Original").build());
+
+      client.putItem(PutItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .item(item1)
+          .build());
+
+      // Overwrite with new item (different attributes)
+      Map<String, AttributeValue> item2 = new HashMap<>();
+      item2.put("id", AttributeValue.builder().s("overwrite-test").build());
+      item2.put("value", AttributeValue.builder().n("200").build());
+      item2.put("description", AttributeValue.builder().s("New attribute").build());
+
+      client.putItem(PutItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .item(item2)
+          .build());
+
+      // Get item and verify complete replacement
+      GetItemResponse response = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(Map.of("id", AttributeValue.builder().s("overwrite-test").build()))
+          .build());
+
+      assertThat(response.item()).containsEntry("value", AttributeValue.builder().n("200").build());
+      assertThat(response.item()).containsEntry("description", AttributeValue.builder().s("New attribute").build());
+      assertThat(response.item()).doesNotContainKey("name");  // Old attribute removed
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ PUT ITEM overwrite test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testUpdateItemNonExistent(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing UPDATE ITEM on non-existent item: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Update item that doesn't exist - should create it
+      Map<String, AttributeValue> key = new HashMap<>();
+      key.put("id", AttributeValue.builder().s("new-item").build());
+
+      Map<String, AttributeValue> updateValues = new HashMap<>();
+      updateValues.put(":value", AttributeValue.builder().n("999").build());
+
+      client.updateItem(UpdateItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key)
+          .updateExpression("SET #value = :value")
+          .expressionAttributeNames(Map.of("#value", "value"))
+          .expressionAttributeValues(updateValues)
+          .build());
+
+      // Verify item was created
+      GetItemResponse response = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key)
+          .build());
+
+      assertThat(response.hasItem()).isTrue();
+      assertThat(response.item()).containsEntry("value", AttributeValue.builder().n("999").build());
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ UPDATE ITEM on non-existent item test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testReturnValuesAllOld(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing ReturnValues ALL_OLD: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Put initial item
+      Map<String, AttributeValue> item = new HashMap<>();
+      item.put("id", AttributeValue.builder().s("return-test").build());
+      item.put("version", AttributeValue.builder().n("1").build());
+      item.put("data", AttributeValue.builder().s("original data").build());
+
+      client.putItem(PutItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .item(item)
+          .build());
+
+      // Update with ALL_OLD
+      Map<String, AttributeValue> key = new HashMap<>();
+      key.put("id", AttributeValue.builder().s("return-test").build());
+
+      Map<String, AttributeValue> updateValues = new HashMap<>();
+      updateValues.put(":newVersion", AttributeValue.builder().n("2").build());
+
+      var updateResponse = client.updateItem(UpdateItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key)
+          .updateExpression("SET version = :newVersion")
+          .expressionAttributeValues(updateValues)
+          .returnValues(ReturnValue.ALL_OLD)
+          .build());
+
+      // Should return old values
+      assertThat(updateResponse.hasAttributes()).isTrue();
+      assertThat(updateResponse.attributes()).containsEntry("version", AttributeValue.builder().n("1").build());
+      assertThat(updateResponse.attributes()).containsEntry("data", AttributeValue.builder().s("original data").build());
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ ReturnValues ALL_OLD test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testUpdateExpressionRemove(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing UPDATE EXPRESSION REMOVE operation: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Put item with multiple attributes
+      Map<String, AttributeValue> item = new HashMap<>();
+      item.put("id", AttributeValue.builder().s("remove-test").build());
+      item.put("attr1", AttributeValue.builder().s("keep me").build());
+      item.put("attr2", AttributeValue.builder().s("remove me").build());
+      item.put("attr3", AttributeValue.builder().n("123").build());
+
+      client.putItem(PutItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .item(item)
+          .build());
+
+      // Remove attr2
+      Map<String, AttributeValue> key = new HashMap<>();
+      key.put("id", AttributeValue.builder().s("remove-test").build());
+
+      client.updateItem(UpdateItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key)
+          .updateExpression("REMOVE attr2")
+          .build());
+
+      // Verify attr2 is removed
+      GetItemResponse response = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key)
+          .build());
+
+      assertThat(response.item()).containsKeys("id", "attr1", "attr3");
+      assertThat(response.item()).doesNotContainKey("attr2");
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ UPDATE EXPRESSION REMOVE test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testUpdateExpressionAddToNumber(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing UPDATE EXPRESSION ADD to number: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Put initial item
+      Map<String, AttributeValue> item = new HashMap<>();
+      item.put("id", AttributeValue.builder().s("add-test").build());
+      item.put("counter", AttributeValue.builder().n("10").build());
+
+      client.putItem(PutItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .item(item)
+          .build());
+
+      // Add to counter (use expression attribute name since "counter" is a reserved keyword)
+      Map<String, AttributeValue> key = new HashMap<>();
+      key.put("id", AttributeValue.builder().s("add-test").build());
+
+      Map<String, AttributeValue> addValues = new HashMap<>();
+      addValues.put(":increment", AttributeValue.builder().n("5").build());
+
+      client.updateItem(UpdateItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key)
+          .updateExpression("ADD #counter :increment")
+          .expressionAttributeNames(Map.of("#counter", "counter"))
+          .expressionAttributeValues(addValues)
+          .build());
+
+      // Verify counter increased
+      GetItemResponse response = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key)
+          .build());
+
+      assertThat(response.item()).containsEntry("counter", AttributeValue.builder().n("15").build());
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ UPDATE EXPRESSION ADD to number test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testUpdateExpressionAddToSet(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing UPDATE EXPRESSION ADD to string set: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Put item with string set
+      Map<String, AttributeValue> item = new HashMap<>();
+      item.put("id", AttributeValue.builder().s("set-test").build());
+      item.put("tags", AttributeValue.builder().ss("tag1", "tag2").build());
+
+      client.putItem(PutItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .item(item)
+          .build());
+
+      // Add to set
+      Map<String, AttributeValue> key = new HashMap<>();
+      key.put("id", AttributeValue.builder().s("set-test").build());
+
+      Map<String, AttributeValue> addValues = new HashMap<>();
+      addValues.put(":newTags", AttributeValue.builder().ss("tag3", "tag4").build());
+
+      client.updateItem(UpdateItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key)
+          .updateExpression("ADD tags :newTags")
+          .expressionAttributeValues(addValues)
+          .build());
+
+      // Verify set has all tags
+      GetItemResponse response = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key)
+          .build());
+
+      assertThat(response.item().get("tags").ss())
+          .containsExactlyInAnyOrder("tag1", "tag2", "tag3", "tag4");
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ UPDATE EXPRESSION ADD to set test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testUpdateExpressionDeleteFromSet(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing UPDATE EXPRESSION DELETE from set: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Put item with string set
+      Map<String, AttributeValue> item = new HashMap<>();
+      item.put("id", AttributeValue.builder().s("delete-set-test").build());
+      item.put("categories", AttributeValue.builder()
+          .ss("electronics", "gadgets", "sale", "new")
+          .build());
+
+      client.putItem(PutItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .item(item)
+          .build());
+
+      // Delete from set
+      Map<String, AttributeValue> key = new HashMap<>();
+      key.put("id", AttributeValue.builder().s("delete-set-test").build());
+
+      Map<String, AttributeValue> deleteValues = new HashMap<>();
+      deleteValues.put(":removeCategories", AttributeValue.builder().ss("sale", "new").build());
+
+      client.updateItem(UpdateItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key)
+          .updateExpression("DELETE categories :removeCategories")
+          .expressionAttributeValues(deleteValues)
+          .build());
+
+      // Verify set has remaining items
+      GetItemResponse response = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key)
+          .build());
+
+      assertThat(response.item().get("categories").ss())
+          .containsExactlyInAnyOrder("electronics", "gadgets");
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ UPDATE EXPRESSION DELETE from set test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testNumberKeyDataTypes(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing number key data types: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+
+      // Create table with number hash key
+      CreateTableRequest request = CreateTableRequest.builder()
+          .tableName(TABLE_NAME)
+          .keySchema(
+              KeySchemaElement.builder()
+                  .attributeName("id")
+                  .keyType(KeyType.HASH)
+                  .build()
+          )
+          .attributeDefinitions(
+              AttributeDefinition.builder()
+                  .attributeName("id")
+                  .attributeType(ScalarAttributeType.N)
+                  .build()
+          )
+          .provisionedThroughput(ProvisionedThroughput.builder()
+              .readCapacityUnits(5L)
+              .writeCapacityUnits(5L)
+              .build())
+          .build();
+
+      client.createTable(request);
+
+      // Put item with number key
+      Map<String, AttributeValue> item = new HashMap<>();
+      item.put("id", AttributeValue.builder().n("12345").build());
+      item.put("data", AttributeValue.builder().s("Number key test").build());
+
+      client.putItem(PutItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .item(item)
+          .build());
+
+      // Get item
+      GetItemResponse response = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(Map.of("id", AttributeValue.builder().n("12345").build()))
+          .build());
+
+      assertThat(response.hasItem()).isTrue();
+      assertThat(response.item()).containsEntry("data", AttributeValue.builder().s("Number key test").build());
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ Number key data types test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testBinaryKeyDataTypes(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing binary key data types: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+
+      // Create table with binary hash key
+      CreateTableRequest request = CreateTableRequest.builder()
+          .tableName(TABLE_NAME)
+          .keySchema(
+              KeySchemaElement.builder()
+                  .attributeName("id")
+                  .keyType(KeyType.HASH)
+                  .build()
+          )
+          .attributeDefinitions(
+              AttributeDefinition.builder()
+                  .attributeName("id")
+                  .attributeType(ScalarAttributeType.B)
+                  .build()
+          )
+          .provisionedThroughput(ProvisionedThroughput.builder()
+              .readCapacityUnits(5L)
+              .writeCapacityUnits(5L)
+              .build())
+          .build();
+
+      client.createTable(request);
+
+      // Put item with binary key
+      SdkBytes binaryKey = SdkBytes.fromString("binary-key-123", StandardCharsets.UTF_8);
+      Map<String, AttributeValue> item = new HashMap<>();
+      item.put("id", AttributeValue.builder().b(binaryKey).build());
+      item.put("data", AttributeValue.builder().s("Binary key test").build());
+
+      client.putItem(PutItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .item(item)
+          .build());
+
+      // Get item
+      GetItemResponse response = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(Map.of("id", AttributeValue.builder().b(binaryKey).build()))
+          .build());
+
+      assertThat(response.hasItem()).isTrue();
+      assertThat(response.item()).containsEntry("data", AttributeValue.builder().s("Binary key test").build());
+      assertThat(response.item().get("id").b().asString(StandardCharsets.UTF_8))
+          .isEqualTo("binary-key-123");
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ Binary key data types test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  private void createSimpleTable(DynamoDbClient client) {
+    CreateTableRequest request = CreateTableRequest.builder()
+        .tableName(TABLE_NAME)
+        .keySchema(
+            KeySchemaElement.builder()
+                .attributeName("id")
+                .keyType(KeyType.HASH)
+                .build()
+        )
+        .attributeDefinitions(
+            AttributeDefinition.builder()
+                .attributeName("id")
+                .attributeType(ScalarAttributeType.S)
+                .build()
+        )
+        .provisionedThroughput(ProvisionedThroughput.builder()
+            .readCapacityUnits(5L)
+            .writeCapacityUnits(5L)
+            .build())
+        .build();
+
+    client.createTable(request);
+  }
+}

--- a/pretender-integ/src/test/java/io/github/pretenderdb/integ/FilterExpressionsIntegrationTest.java
+++ b/pretender-integ/src/test/java/io/github/pretenderdb/integ/FilterExpressionsIntegrationTest.java
@@ -1,0 +1,389 @@
+package io.github.pretenderdb.integ;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
+
+/**
+ * Integration test that validates filter expressions work identically
+ * across DynamoDB Local and Pretender implementations.
+ */
+class FilterExpressionsIntegrationTest {
+
+  private static final Logger log = LoggerFactory.getLogger(FilterExpressionsIntegrationTest.class);
+  private static final String TABLE_NAME = "FilterTestTable";
+
+  static Stream<DynamoDbProvider> dynamoDbProviders() {
+    return Stream.of(
+        new DynamoDbLocalProvider(),
+        new PretenderPostgresProvider(),
+        new PretenderHsqldbProvider()
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testScanWithSimpleFilterExpression(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing SCAN with simple filter expression: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Write items with different ages
+      for (int i = 1; i <= 10; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("id", AttributeValue.builder().s("user-" + i).build());
+        item.put("age", AttributeValue.builder().n(String.valueOf(20 + i)).build());
+        item.put("name", AttributeValue.builder().s("User " + i).build());
+
+        client.putItem(PutItemRequest.builder()
+            .tableName(TABLE_NAME)
+            .item(item)
+            .build());
+      }
+
+      // Scan with filter: age >= 25
+      Map<String, AttributeValue> filterValues = new HashMap<>();
+      filterValues.put(":minAge", AttributeValue.builder().n("25").build());
+
+      ScanResponse scanResponse = client.scan(ScanRequest.builder()
+          .tableName(TABLE_NAME)
+          .filterExpression("age >= :minAge")
+          .expressionAttributeValues(filterValues)
+          .build());
+
+      // Should get users with age 25-30 (users 5-10 = 6 items)
+      assertThat(scanResponse.count()).isEqualTo(6);
+      assertThat(scanResponse.scannedCount()).isEqualTo(10);  // All items scanned
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ SCAN with simple filter test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testQueryWithFilterExpression(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing QUERY with filter expression: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createTableWithRangeKey(client);
+
+      // Write items
+      for (int i = 1; i <= 8; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("userId", AttributeValue.builder().s("user-123").build());
+        item.put("timestamp", AttributeValue.builder().n(String.valueOf(1000 + i)).build());
+        item.put("amount", AttributeValue.builder().n(String.valueOf(i * 50)).build());
+        item.put("type", AttributeValue.builder().s(i % 2 == 0 ? "credit" : "debit").build());
+
+        client.putItem(PutItemRequest.builder()
+            .tableName(TABLE_NAME)
+            .item(item)
+            .build());
+      }
+
+      // Query with key condition and filter expression
+      Map<String, AttributeValue> expressionValues = new HashMap<>();
+      expressionValues.put(":userId", AttributeValue.builder().s("user-123").build());
+      expressionValues.put(":minAmount", AttributeValue.builder().n("200").build());
+      expressionValues.put(":type", AttributeValue.builder().s("credit").build());
+
+      QueryResponse queryResponse = client.query(QueryRequest.builder()
+          .tableName(TABLE_NAME)
+          .keyConditionExpression("userId = :userId")
+          .filterExpression("amount >= :minAmount AND #type = :type")
+          .expressionAttributeNames(Map.of("#type", "type"))
+          .expressionAttributeValues(expressionValues)
+          .build());
+
+      // Credits with amount >= 200: items 4, 6, 8 (amounts 200, 300, 400)
+      assertThat(queryResponse.count()).isEqualTo(3);
+      assertThat(queryResponse.scannedCount()).isEqualTo(8);
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ QUERY with filter test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testFilterWithAttributeExists(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing filter with attribute_exists: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Write items, some with email and some without
+      for (int i = 1; i <= 6; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("id", AttributeValue.builder().s("user-" + i).build());
+        item.put("name", AttributeValue.builder().s("User " + i).build());
+
+        // Only odd numbered users have email
+        if (i % 2 == 1) {
+          item.put("email", AttributeValue.builder().s("user" + i + "@example.com").build());
+        }
+
+        client.putItem(PutItemRequest.builder()
+            .tableName(TABLE_NAME)
+            .item(item)
+            .build());
+      }
+
+      // Scan for items with email
+      ScanResponse scanResponse = client.scan(ScanRequest.builder()
+          .tableName(TABLE_NAME)
+          .filterExpression("attribute_exists(email)")
+          .build());
+
+      // Should get users 1, 3, 5 (3 items)
+      assertThat(scanResponse.count()).isEqualTo(3);
+      assertThat(scanResponse.scannedCount()).isEqualTo(6);
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ Filter with attribute_exists test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testFilterWithBeginsWithFunction(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing filter with begins_with function: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Write items with different prefixes
+      String[] names = {"admin-user1", "admin-user2", "user3", "admin-user4", "guest5", "user6"};
+      for (int i = 0; i < names.length; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("id", AttributeValue.builder().s("id-" + i).build());
+        item.put("username", AttributeValue.builder().s(names[i]).build());
+
+        client.putItem(PutItemRequest.builder()
+            .tableName(TABLE_NAME)
+            .item(item)
+            .build());
+      }
+
+      // Scan for usernames beginning with "admin-"
+      Map<String, AttributeValue> filterValues = new HashMap<>();
+      filterValues.put(":prefix", AttributeValue.builder().s("admin-").build());
+
+      ScanResponse scanResponse = client.scan(ScanRequest.builder()
+          .tableName(TABLE_NAME)
+          .filterExpression("begins_with(username, :prefix)")
+          .expressionAttributeValues(filterValues)
+          .build());
+
+      // Should get admin-user1, admin-user2, admin-user4 (3 items)
+      assertThat(scanResponse.count()).isEqualTo(3);
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ Filter with begins_with test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testFilterWithContainsFunction(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing filter with contains function: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Write items with tags
+      Map<String, AttributeValue> item1 = new HashMap<>();
+      item1.put("id", AttributeValue.builder().s("item-1").build());
+      item1.put("tags", AttributeValue.builder().ss("important", "urgent", "review").build());
+
+      Map<String, AttributeValue> item2 = new HashMap<>();
+      item2.put("id", AttributeValue.builder().s("item-2").build());
+      item2.put("tags", AttributeValue.builder().ss("normal", "pending").build());
+
+      Map<String, AttributeValue> item3 = new HashMap<>();
+      item3.put("id", AttributeValue.builder().s("item-3").build());
+      item3.put("tags", AttributeValue.builder().ss("important", "archived").build());
+
+      client.putItem(PutItemRequest.builder().tableName(TABLE_NAME).item(item1).build());
+      client.putItem(PutItemRequest.builder().tableName(TABLE_NAME).item(item2).build());
+      client.putItem(PutItemRequest.builder().tableName(TABLE_NAME).item(item3).build());
+
+      // Scan for items containing "important" tag
+      Map<String, AttributeValue> filterValues = new HashMap<>();
+      filterValues.put(":tag", AttributeValue.builder().s("important").build());
+
+      ScanResponse scanResponse = client.scan(ScanRequest.builder()
+          .tableName(TABLE_NAME)
+          .filterExpression("contains(tags, :tag)")
+          .expressionAttributeValues(filterValues)
+          .build());
+
+      // Should get item-1 and item-3 (2 items)
+      assertThat(scanResponse.count()).isEqualTo(2);
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ Filter with contains test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testFilterWithComplexLogicalOperators(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing filter with complex logical operators: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Write items
+      for (int i = 1; i <= 10; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("id", AttributeValue.builder().s("product-" + i).build());
+        item.put("price", AttributeValue.builder().n(String.valueOf(i * 10)).build());
+        item.put("inStock", AttributeValue.builder().bool(i % 3 != 0).build());
+        item.put("featured", AttributeValue.builder().bool(i % 2 == 0).build());
+
+        client.putItem(PutItemRequest.builder()
+            .tableName(TABLE_NAME)
+            .item(item)
+            .build());
+      }
+
+      // Filter: (price >= 30 AND price <= 70) AND (inStock = true OR featured = true)
+      Map<String, AttributeValue> filterValues = new HashMap<>();
+      filterValues.put(":minPrice", AttributeValue.builder().n("30").build());
+      filterValues.put(":maxPrice", AttributeValue.builder().n("70").build());
+      filterValues.put(":true", AttributeValue.builder().bool(true).build());
+
+      ScanResponse scanResponse = client.scan(ScanRequest.builder()
+          .tableName(TABLE_NAME)
+          .filterExpression("(price >= :minPrice AND price <= :maxPrice) AND (inStock = :true OR featured = :true)")
+          .expressionAttributeValues(filterValues)
+          .build());
+
+      // Products 3-7 with price 30-70
+      // Product 3: inStock=false, featured=false -> excluded
+      // Product 4: inStock=true, featured=true -> included
+      // Product 5: inStock=true, featured=false -> included
+      // Product 6: inStock=false, featured=true -> included
+      // Product 7: inStock=true, featured=false -> included
+      assertThat(scanResponse.count()).isEqualTo(4);
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ Filter with complex logical operators test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  private void createSimpleTable(DynamoDbClient client) {
+    CreateTableRequest request = CreateTableRequest.builder()
+        .tableName(TABLE_NAME)
+        .keySchema(
+            KeySchemaElement.builder()
+                .attributeName("id")
+                .keyType(KeyType.HASH)
+                .build()
+        )
+        .attributeDefinitions(
+            AttributeDefinition.builder()
+                .attributeName("id")
+                .attributeType(ScalarAttributeType.S)
+                .build()
+        )
+        .provisionedThroughput(ProvisionedThroughput.builder()
+            .readCapacityUnits(5L)
+            .writeCapacityUnits(5L)
+            .build())
+        .build();
+
+    client.createTable(request);
+  }
+
+  private void createTableWithRangeKey(DynamoDbClient client) {
+    CreateTableRequest request = CreateTableRequest.builder()
+        .tableName(TABLE_NAME)
+        .keySchema(
+            KeySchemaElement.builder()
+                .attributeName("userId")
+                .keyType(KeyType.HASH)
+                .build(),
+            KeySchemaElement.builder()
+                .attributeName("timestamp")
+                .keyType(KeyType.RANGE)
+                .build()
+        )
+        .attributeDefinitions(
+            AttributeDefinition.builder()
+                .attributeName("userId")
+                .attributeType(ScalarAttributeType.S)
+                .build(),
+            AttributeDefinition.builder()
+                .attributeName("timestamp")
+                .attributeType(ScalarAttributeType.N)
+                .build()
+        )
+        .provisionedThroughput(ProvisionedThroughput.builder()
+            .readCapacityUnits(5L)
+            .writeCapacityUnits(5L)
+            .build())
+        .build();
+
+    client.createTable(request);
+  }
+}

--- a/pretender-integ/src/test/java/io/github/pretenderdb/integ/GsiIntegrationTest.java
+++ b/pretender-integ/src/test/java/io/github/pretenderdb/integ/GsiIntegrationTest.java
@@ -1,0 +1,518 @@
+package io.github.pretenderdb.integ;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.GlobalSecondaryIndex;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.Projection;
+import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
+
+/**
+ * Integration test that validates Global Secondary Index operations work identically
+ * across DynamoDB Local and Pretender implementations.
+ */
+class GsiIntegrationTest {
+
+  private static final Logger log = LoggerFactory.getLogger(GsiIntegrationTest.class);
+  private static final String TABLE_NAME = "GsiTestTable";
+  private static final String GSI_NAME = "StatusIndex";
+
+  static Stream<DynamoDbProvider> dynamoDbProviders() {
+    return Stream.of(
+        new DynamoDbLocalProvider(),
+        new PretenderPostgresProvider(),
+        new PretenderHsqldbProvider()
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testCreateTableWithGsi(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing CREATE TABLE with GSI: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+
+      // Create table with GSI
+      CreateTableRequest request = CreateTableRequest.builder()
+          .tableName(TABLE_NAME)
+          .keySchema(
+              KeySchemaElement.builder()
+                  .attributeName("id")
+                  .keyType(KeyType.HASH)
+                  .build()
+          )
+          .attributeDefinitions(
+              AttributeDefinition.builder()
+                  .attributeName("id")
+                  .attributeType(ScalarAttributeType.S)
+                  .build(),
+              AttributeDefinition.builder()
+                  .attributeName("status")
+                  .attributeType(ScalarAttributeType.S)
+                  .build()
+          )
+          .globalSecondaryIndexes(
+              GlobalSecondaryIndex.builder()
+                  .indexName(GSI_NAME)
+                  .keySchema(
+                      KeySchemaElement.builder()
+                          .attributeName("status")
+                          .keyType(KeyType.HASH)
+                          .build()
+                  )
+                  .projection(Projection.builder()
+                      .projectionType(ProjectionType.ALL)
+                      .build())
+                  .provisionedThroughput(ProvisionedThroughput.builder()
+                      .readCapacityUnits(5L)
+                      .writeCapacityUnits(5L)
+                      .build())
+                  .build()
+          )
+          .provisionedThroughput(ProvisionedThroughput.builder()
+              .readCapacityUnits(5L)
+              .writeCapacityUnits(5L)
+              .build())
+          .build();
+
+      client.createTable(request);
+
+      // Write an item and query via GSI
+      Map<String, AttributeValue> item = new HashMap<>();
+      item.put("id", AttributeValue.builder().s("test-id").build());
+      item.put("status", AttributeValue.builder().s("active").build());
+      item.put("name", AttributeValue.builder().s("Test Item").build());
+
+      client.putItem(PutItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .item(item)
+          .build());
+
+      // Query via GSI
+      Map<String, AttributeValue> expressionValues = new HashMap<>();
+      expressionValues.put(":status", AttributeValue.builder().s("active").build());
+
+      QueryResponse queryResponse = client.query(QueryRequest.builder()
+          .tableName(TABLE_NAME)
+          .indexName(GSI_NAME)
+          .keyConditionExpression("#status = :status")
+          .expressionAttributeNames(Map.of("#status", "status"))
+          .expressionAttributeValues(expressionValues)
+          .build());
+
+      assertThat(queryResponse.count()).isEqualTo(1);
+      assertThat(queryResponse.items().get(0))
+          .containsEntry("id", AttributeValue.builder().s("test-id").build());
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ CREATE TABLE with GSI test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testQueryGsiWithMultipleItems(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing QUERY GSI with multiple items: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createTableWithGsi(client);
+
+      // Write items with different statuses
+      String[] statuses = {"active", "active", "pending", "active", "inactive", "pending"};
+      for (int i = 0; i < statuses.length; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("id", AttributeValue.builder().s("item-" + i).build());
+        item.put("status", AttributeValue.builder().s(statuses[i]).build());
+        item.put("value", AttributeValue.builder().n(String.valueOf(i * 10)).build());
+
+        client.putItem(PutItemRequest.builder()
+            .tableName(TABLE_NAME)
+            .item(item)
+            .build());
+      }
+
+      // Query for active items via GSI
+      Map<String, AttributeValue> expressionValues = new HashMap<>();
+      expressionValues.put(":status", AttributeValue.builder().s("active").build());
+
+      QueryResponse queryResponse = client.query(QueryRequest.builder()
+          .tableName(TABLE_NAME)
+          .indexName(GSI_NAME)
+          .keyConditionExpression("#status = :status")
+          .expressionAttributeNames(Map.of("#status", "status"))
+          .expressionAttributeValues(expressionValues)
+          .build());
+
+      // Should get 3 active items
+      assertThat(queryResponse.count()).isEqualTo(3);
+      assertThat(queryResponse.items()).hasSize(3);
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ QUERY GSI with multiple items test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testGsiWithHashAndRangeKey(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing GSI with hash and range key: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+
+      // Create table with GSI that has both hash and range key
+      CreateTableRequest request = CreateTableRequest.builder()
+          .tableName(TABLE_NAME)
+          .keySchema(
+              KeySchemaElement.builder()
+                  .attributeName("id")
+                  .keyType(KeyType.HASH)
+                  .build()
+          )
+          .attributeDefinitions(
+              AttributeDefinition.builder()
+                  .attributeName("id")
+                  .attributeType(ScalarAttributeType.S)
+                  .build(),
+              AttributeDefinition.builder()
+                  .attributeName("category")
+                  .attributeType(ScalarAttributeType.S)
+                  .build(),
+              AttributeDefinition.builder()
+                  .attributeName("timestamp")
+                  .attributeType(ScalarAttributeType.S)
+                  .build()
+          )
+          .globalSecondaryIndexes(
+              GlobalSecondaryIndex.builder()
+                  .indexName("CategoryTimestampIndex")
+                  .keySchema(
+                      KeySchemaElement.builder()
+                          .attributeName("category")
+                          .keyType(KeyType.HASH)
+                          .build(),
+                      KeySchemaElement.builder()
+                          .attributeName("timestamp")
+                          .keyType(KeyType.RANGE)
+                          .build()
+                  )
+                  .projection(Projection.builder()
+                      .projectionType(ProjectionType.ALL)
+                      .build())
+                  .provisionedThroughput(ProvisionedThroughput.builder()
+                      .readCapacityUnits(5L)
+                      .writeCapacityUnits(5L)
+                      .build())
+                  .build()
+          )
+          .provisionedThroughput(ProvisionedThroughput.builder()
+              .readCapacityUnits(5L)
+              .writeCapacityUnits(5L)
+              .build())
+          .build();
+
+      client.createTable(request);
+
+      // Write items with same category but different timestamps
+      for (int i = 1; i <= 5; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("id", AttributeValue.builder().s("event-" + i).build());
+        item.put("category", AttributeValue.builder().s("sports").build());
+        item.put("timestamp", AttributeValue.builder().s("2024-01-0" + i).build());
+        item.put("description", AttributeValue.builder().s("Event " + i).build());
+
+        client.putItem(PutItemRequest.builder()
+            .tableName(TABLE_NAME)
+            .item(item)
+            .build());
+      }
+
+      // Query GSI with hash key only
+      Map<String, AttributeValue> hashOnlyValues = new HashMap<>();
+      hashOnlyValues.put(":category", AttributeValue.builder().s("sports").build());
+
+      QueryResponse allSportsResponse = client.query(QueryRequest.builder()
+          .tableName(TABLE_NAME)
+          .indexName("CategoryTimestampIndex")
+          .keyConditionExpression("category = :category")
+          .expressionAttributeValues(hashOnlyValues)
+          .build());
+
+      assertThat(allSportsResponse.count()).isEqualTo(5);
+
+      // Query GSI with hash and range key condition
+      Map<String, AttributeValue> rangeValues = new HashMap<>();
+      rangeValues.put(":category", AttributeValue.builder().s("sports").build());
+      rangeValues.put(":startDate", AttributeValue.builder().s("2024-01-03").build());
+
+      QueryResponse filteredResponse = client.query(QueryRequest.builder()
+          .tableName(TABLE_NAME)
+          .indexName("CategoryTimestampIndex")
+          .keyConditionExpression("category = :category AND #timestamp >= :startDate")
+          .expressionAttributeNames(Map.of("#timestamp", "timestamp"))
+          .expressionAttributeValues(rangeValues)
+          .build());
+
+      assertThat(filteredResponse.count()).isEqualTo(3);
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ GSI with hash and range key test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testGsiProjectionKeysOnly(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing GSI with KEYS_ONLY projection: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+
+      // Create table with KEYS_ONLY projection GSI
+      CreateTableRequest request = CreateTableRequest.builder()
+          .tableName(TABLE_NAME)
+          .keySchema(
+              KeySchemaElement.builder()
+                  .attributeName("id")
+                  .keyType(KeyType.HASH)
+                  .build()
+          )
+          .attributeDefinitions(
+              AttributeDefinition.builder()
+                  .attributeName("id")
+                  .attributeType(ScalarAttributeType.S)
+                  .build(),
+              AttributeDefinition.builder()
+                  .attributeName("status")
+                  .attributeType(ScalarAttributeType.S)
+                  .build()
+          )
+          .globalSecondaryIndexes(
+              GlobalSecondaryIndex.builder()
+                  .indexName(GSI_NAME)
+                  .keySchema(
+                      KeySchemaElement.builder()
+                          .attributeName("status")
+                          .keyType(KeyType.HASH)
+                          .build()
+                  )
+                  .projection(Projection.builder()
+                      .projectionType(ProjectionType.KEYS_ONLY)
+                      .build())
+                  .provisionedThroughput(ProvisionedThroughput.builder()
+                      .readCapacityUnits(5L)
+                      .writeCapacityUnits(5L)
+                      .build())
+                  .build()
+          )
+          .provisionedThroughput(ProvisionedThroughput.builder()
+              .readCapacityUnits(5L)
+              .writeCapacityUnits(5L)
+              .build())
+          .build();
+
+      client.createTable(request);
+
+      // Write item with multiple attributes
+      Map<String, AttributeValue> item = new HashMap<>();
+      item.put("id", AttributeValue.builder().s("keys-test").build());
+      item.put("status", AttributeValue.builder().s("active").build());
+      item.put("name", AttributeValue.builder().s("Should not be in GSI").build());
+      item.put("description", AttributeValue.builder().s("Extra data").build());
+
+      client.putItem(PutItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .item(item)
+          .build());
+
+      // Query GSI
+      Map<String, AttributeValue> expressionValues = new HashMap<>();
+      expressionValues.put(":status", AttributeValue.builder().s("active").build());
+
+      QueryResponse queryResponse = client.query(QueryRequest.builder()
+          .tableName(TABLE_NAME)
+          .indexName(GSI_NAME)
+          .keyConditionExpression("#status = :status")
+          .expressionAttributeNames(Map.of("#status", "status"))
+          .expressionAttributeValues(expressionValues)
+          .build());
+
+      assertThat(queryResponse.count()).isEqualTo(1);
+
+      // With KEYS_ONLY projection, only table keys and GSI keys are returned
+      Map<String, AttributeValue> resultItem = queryResponse.items().get(0);
+      assertThat(resultItem).containsKey("id");  // table key
+      assertThat(resultItem).containsKey("status");  // GSI key
+      assertThat(resultItem).doesNotContainKey("name");  // not projected
+      assertThat(resultItem).doesNotContainKey("description");  // not projected
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ GSI with KEYS_ONLY projection test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testGsiUpdateOnItemModification(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing GSI update on item modification: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createTableWithGsi(client);
+
+      // Write initial item
+      Map<String, AttributeValue> item = new HashMap<>();
+      item.put("id", AttributeValue.builder().s("update-test").build());
+      item.put("status", AttributeValue.builder().s("pending").build());
+      item.put("value", AttributeValue.builder().n("100").build());
+
+      client.putItem(PutItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .item(item)
+          .build());
+
+      // Verify item appears in GSI under "pending" status
+      QueryResponse pendingQuery = client.query(QueryRequest.builder()
+          .tableName(TABLE_NAME)
+          .indexName(GSI_NAME)
+          .keyConditionExpression("#status = :status")
+          .expressionAttributeNames(Map.of("#status", "status"))
+          .expressionAttributeValues(Map.of(":status", AttributeValue.builder().s("pending").build()))
+          .build());
+
+      assertThat(pendingQuery.count()).isEqualTo(1);
+
+      // Update item status (GSI key change)
+      Map<String, AttributeValue> key = new HashMap<>();
+      key.put("id", AttributeValue.builder().s("update-test").build());
+
+      Map<String, AttributeValue> updateValues = new HashMap<>();
+      updateValues.put(":newStatus", AttributeValue.builder().s("active").build());
+
+      client.updateItem(UpdateItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(key)
+          .updateExpression("SET #status = :newStatus")
+          .expressionAttributeNames(Map.of("#status", "status"))
+          .expressionAttributeValues(updateValues)
+          .build());
+
+      // Verify item no longer appears under "pending"
+      QueryResponse pendingAfterUpdate = client.query(QueryRequest.builder()
+          .tableName(TABLE_NAME)
+          .indexName(GSI_NAME)
+          .keyConditionExpression("#status = :status")
+          .expressionAttributeNames(Map.of("#status", "status"))
+          .expressionAttributeValues(Map.of(":status", AttributeValue.builder().s("pending").build()))
+          .build());
+
+      assertThat(pendingAfterUpdate.count()).isEqualTo(0);
+
+      // Verify item now appears under "active"
+      QueryResponse activeQuery = client.query(QueryRequest.builder()
+          .tableName(TABLE_NAME)
+          .indexName(GSI_NAME)
+          .keyConditionExpression("#status = :status")
+          .expressionAttributeNames(Map.of("#status", "status"))
+          .expressionAttributeValues(Map.of(":status", AttributeValue.builder().s("active").build()))
+          .build());
+
+      assertThat(activeQuery.count()).isEqualTo(1);
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ GSI update on item modification test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  private void createTableWithGsi(DynamoDbClient client) {
+    CreateTableRequest request = CreateTableRequest.builder()
+        .tableName(TABLE_NAME)
+        .keySchema(
+            KeySchemaElement.builder()
+                .attributeName("id")
+                .keyType(KeyType.HASH)
+                .build()
+        )
+        .attributeDefinitions(
+            AttributeDefinition.builder()
+                .attributeName("id")
+                .attributeType(ScalarAttributeType.S)
+                .build(),
+            AttributeDefinition.builder()
+                .attributeName("status")
+                .attributeType(ScalarAttributeType.S)
+                .build()
+        )
+        .globalSecondaryIndexes(
+            GlobalSecondaryIndex.builder()
+                .indexName(GSI_NAME)
+                .keySchema(
+                    KeySchemaElement.builder()
+                        .attributeName("status")
+                        .keyType(KeyType.HASH)
+                        .build()
+                )
+                .projection(Projection.builder()
+                    .projectionType(ProjectionType.ALL)
+                    .build())
+                .provisionedThroughput(ProvisionedThroughput.builder()
+                    .readCapacityUnits(5L)
+                    .writeCapacityUnits(5L)
+                    .build())
+                .build()
+        )
+        .provisionedThroughput(ProvisionedThroughput.builder()
+            .readCapacityUnits(5L)
+            .writeCapacityUnits(5L)
+            .build())
+        .build();
+
+    client.createTable(request);
+  }
+}

--- a/pretender-integ/src/test/java/io/github/pretenderdb/integ/PaginationIntegrationTest.java
+++ b/pretender-integ/src/test/java/io/github/pretenderdb/integ/PaginationIntegrationTest.java
@@ -1,0 +1,424 @@
+package io.github.pretenderdb.integ;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
+
+/**
+ * Integration test that validates pagination works identically
+ * across DynamoDB Local and Pretender implementations.
+ */
+class PaginationIntegrationTest {
+
+  private static final Logger log = LoggerFactory.getLogger(PaginationIntegrationTest.class);
+  private static final String TABLE_NAME = "PaginationTestTable";
+
+  static Stream<DynamoDbProvider> dynamoDbProviders() {
+    return Stream.of(
+        new DynamoDbLocalProvider(),
+        new PretenderPostgresProvider(),
+        new PretenderHsqldbProvider()
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testScanWithPagination(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing SCAN with pagination: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Write 20 items
+      for (int i = 1; i <= 20; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("id", AttributeValue.builder().s(String.format("item-%02d", i)).build());
+        item.put("value", AttributeValue.builder().n(String.valueOf(i)).build());
+
+        client.putItem(PutItemRequest.builder()
+            .tableName(TABLE_NAME)
+            .item(item)
+            .build());
+      }
+
+      // Scan with limit (page size of 5)
+      List<Map<String, AttributeValue>> allItems = new ArrayList<>();
+      Map<String, AttributeValue> lastEvaluatedKey = null;
+      int pageCount = 0;
+
+      do {
+        ScanRequest.Builder scanBuilder = ScanRequest.builder()
+            .tableName(TABLE_NAME)
+            .limit(5);
+
+        if (lastEvaluatedKey != null) {
+          scanBuilder.exclusiveStartKey(lastEvaluatedKey);
+        }
+
+        ScanResponse response = client.scan(scanBuilder.build());
+        allItems.addAll(response.items());
+        lastEvaluatedKey = response.hasLastEvaluatedKey() ? response.lastEvaluatedKey() : null;
+        pageCount++;
+
+        // Each page should have at most 5 items
+        assertThat(response.items()).hasSizeLessThanOrEqualTo(5);
+      } while (lastEvaluatedKey != null);
+
+      // Should have gotten all 20 items
+      // Note: Page count may vary based on implementation internals
+      assertThat(allItems).hasSize(20);
+      assertThat(pageCount).isGreaterThanOrEqualTo(4);
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ SCAN with pagination test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testQueryWithPagination(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing QUERY with pagination: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createTableWithRangeKey(client);
+
+      // Write 15 items with same hash key
+      for (int i = 1; i <= 15; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("userId", AttributeValue.builder().s("user-123").build());
+        item.put("timestamp", AttributeValue.builder().n(String.valueOf(1000 + i)).build());
+        item.put("message", AttributeValue.builder().s("Message " + i).build());
+
+        client.putItem(PutItemRequest.builder()
+            .tableName(TABLE_NAME)
+            .item(item)
+            .build());
+      }
+
+      // Query with pagination (page size of 4)
+      List<Map<String, AttributeValue>> allItems = new ArrayList<>();
+      Map<String, AttributeValue> lastEvaluatedKey = null;
+      int pageCount = 0;
+
+      Map<String, AttributeValue> keyConditionValues = new HashMap<>();
+      keyConditionValues.put(":userId", AttributeValue.builder().s("user-123").build());
+
+      do {
+        QueryRequest.Builder queryBuilder = QueryRequest.builder()
+            .tableName(TABLE_NAME)
+            .keyConditionExpression("userId = :userId")
+            .expressionAttributeValues(keyConditionValues)
+            .limit(4);
+
+        if (lastEvaluatedKey != null) {
+          queryBuilder.exclusiveStartKey(lastEvaluatedKey);
+        }
+
+        QueryResponse response = client.query(queryBuilder.build());
+        allItems.addAll(response.items());
+        lastEvaluatedKey = response.hasLastEvaluatedKey() ? response.lastEvaluatedKey() : null;
+        pageCount++;
+
+        assertThat(response.items()).hasSizeLessThanOrEqualTo(4);
+      } while (lastEvaluatedKey != null);
+
+      // Should have gotten all 15 items across 4 pages (4+4+4+3)
+      assertThat(allItems).hasSize(15);
+      assertThat(pageCount).isEqualTo(4);
+
+      // Verify items are in sort key order
+      for (int i = 0; i < allItems.size() - 1; i++) {
+        int currentTimestamp = Integer.parseInt(allItems.get(i).get("timestamp").n());
+        int nextTimestamp = Integer.parseInt(allItems.get(i + 1).get("timestamp").n());
+        assertThat(currentTimestamp).isLessThan(nextTimestamp);
+      }
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ QUERY with pagination test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testScanWithFilterAndPagination(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing SCAN with filter and pagination: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Write 30 items (15 even, 15 odd)
+      for (int i = 1; i <= 30; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("id", AttributeValue.builder().s(String.format("item-%02d", i)).build());
+        item.put("value", AttributeValue.builder().n(String.valueOf(i)).build());
+        item.put("category", AttributeValue.builder().s(i % 2 == 0 ? "even" : "odd").build());
+
+        client.putItem(PutItemRequest.builder()
+            .tableName(TABLE_NAME)
+            .item(item)
+            .build());
+      }
+
+      // Scan with filter for "even" category and pagination
+      List<Map<String, AttributeValue>> allEvenItems = new ArrayList<>();
+      Map<String, AttributeValue> lastEvaluatedKey = null;
+      int totalScanned = 0;
+
+      Map<String, AttributeValue> filterValues = new HashMap<>();
+      filterValues.put(":category", AttributeValue.builder().s("even").build());
+
+      do {
+        ScanRequest.Builder scanBuilder = ScanRequest.builder()
+            .tableName(TABLE_NAME)
+            .filterExpression("category = :category")
+            .expressionAttributeValues(filterValues)
+            .limit(10);  // Scan limit (not result limit)
+
+        if (lastEvaluatedKey != null) {
+          scanBuilder.exclusiveStartKey(lastEvaluatedKey);
+        }
+
+        ScanResponse response = client.scan(scanBuilder.build());
+        allEvenItems.addAll(response.items());
+        lastEvaluatedKey = response.hasLastEvaluatedKey() ? response.lastEvaluatedKey() : null;
+        totalScanned += response.scannedCount();
+      } while (lastEvaluatedKey != null);
+
+      // Should get 15 even items (filtered from 30 total)
+      assertThat(allEvenItems).hasSize(15);
+      assertThat(totalScanned).isEqualTo(30);  // All items were scanned
+
+      // Verify all returned items are "even"
+      for (Map<String, AttributeValue> item : allEvenItems) {
+        assertThat(item.get("category").s()).isEqualTo("even");
+      }
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ SCAN with filter and pagination test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testQueryWithRangeKeyConditionAndPagination(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing QUERY with range key condition and pagination: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createTableWithRangeKey(client);
+
+      // Write 20 items
+      for (int i = 1; i <= 20; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("userId", AttributeValue.builder().s("user-456").build());
+        item.put("timestamp", AttributeValue.builder().n(String.valueOf(2000 + i)).build());
+        item.put("data", AttributeValue.builder().s("Data " + i).build());
+
+        client.putItem(PutItemRequest.builder()
+            .tableName(TABLE_NAME)
+            .item(item)
+            .build());
+      }
+
+      // Query with range key condition (timestamp >= 2010) and pagination
+      List<Map<String, AttributeValue>> allItems = new ArrayList<>();
+      Map<String, AttributeValue> lastEvaluatedKey = null;
+
+      Map<String, AttributeValue> keyConditionValues = new HashMap<>();
+      keyConditionValues.put(":userId", AttributeValue.builder().s("user-456").build());
+      keyConditionValues.put(":minTimestamp", AttributeValue.builder().n("2010").build());
+
+      do {
+        QueryRequest.Builder queryBuilder = QueryRequest.builder()
+            .tableName(TABLE_NAME)
+            .keyConditionExpression("userId = :userId AND #timestamp >= :minTimestamp")
+            .expressionAttributeNames(Map.of("#timestamp", "timestamp"))
+            .expressionAttributeValues(keyConditionValues)
+            .limit(3);
+
+        if (lastEvaluatedKey != null) {
+          queryBuilder.exclusiveStartKey(lastEvaluatedKey);
+        }
+
+        QueryResponse response = client.query(queryBuilder.build());
+        allItems.addAll(response.items());
+        lastEvaluatedKey = response.hasLastEvaluatedKey() ? response.lastEvaluatedKey() : null;
+      } while (lastEvaluatedKey != null);
+
+      // Should get items with timestamp 2010-2020 (11 items)
+      assertThat(allItems).hasSize(11);
+
+      // Verify all items meet the range key condition
+      for (Map<String, AttributeValue> item : allItems) {
+        int timestamp = Integer.parseInt(item.get("timestamp").n());
+        assertThat(timestamp).isGreaterThanOrEqualTo(2010);
+      }
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ QUERY with range key condition and pagination test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testScanWithProjectionExpressionAndPagination(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing SCAN with projection expression and pagination: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Write items with multiple attributes
+      for (int i = 1; i <= 12; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("id", AttributeValue.builder().s("proj-" + i).build());
+        item.put("name", AttributeValue.builder().s("Name " + i).build());
+        item.put("email", AttributeValue.builder().s("user" + i + "@example.com").build());
+        item.put("age", AttributeValue.builder().n(String.valueOf(20 + i)).build());
+        item.put("address", AttributeValue.builder().s("Address " + i).build());
+
+        client.putItem(PutItemRequest.builder()
+            .tableName(TABLE_NAME)
+            .item(item)
+            .build());
+      }
+
+      // Scan with projection (only id and name) and pagination
+      List<Map<String, AttributeValue>> allItems = new ArrayList<>();
+      Map<String, AttributeValue> lastEvaluatedKey = null;
+
+      do {
+        ScanRequest.Builder scanBuilder = ScanRequest.builder()
+            .tableName(TABLE_NAME)
+            .projectionExpression("id, #name")
+            .expressionAttributeNames(Map.of("#name", "name"))
+            .limit(5);
+
+        if (lastEvaluatedKey != null) {
+          scanBuilder.exclusiveStartKey(lastEvaluatedKey);
+        }
+
+        ScanResponse response = client.scan(scanBuilder.build());
+        allItems.addAll(response.items());
+        lastEvaluatedKey = response.hasLastEvaluatedKey() ? response.lastEvaluatedKey() : null;
+      } while (lastEvaluatedKey != null);
+
+      assertThat(allItems).hasSize(12);
+
+      // Verify projection - each item should only have id and name
+      for (Map<String, AttributeValue> item : allItems) {
+        assertThat(item).containsKeys("id", "name");
+        assertThat(item).doesNotContainKeys("email", "age", "address");
+      }
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ SCAN with projection expression and pagination test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  private void createSimpleTable(DynamoDbClient client) {
+    CreateTableRequest request = CreateTableRequest.builder()
+        .tableName(TABLE_NAME)
+        .keySchema(
+            KeySchemaElement.builder()
+                .attributeName("id")
+                .keyType(KeyType.HASH)
+                .build()
+        )
+        .attributeDefinitions(
+            AttributeDefinition.builder()
+                .attributeName("id")
+                .attributeType(ScalarAttributeType.S)
+                .build()
+        )
+        .provisionedThroughput(ProvisionedThroughput.builder()
+            .readCapacityUnits(5L)
+            .writeCapacityUnits(5L)
+            .build())
+        .build();
+
+    client.createTable(request);
+  }
+
+  private void createTableWithRangeKey(DynamoDbClient client) {
+    CreateTableRequest request = CreateTableRequest.builder()
+        .tableName(TABLE_NAME)
+        .keySchema(
+            KeySchemaElement.builder()
+                .attributeName("userId")
+                .keyType(KeyType.HASH)
+                .build(),
+            KeySchemaElement.builder()
+                .attributeName("timestamp")
+                .keyType(KeyType.RANGE)
+                .build()
+        )
+        .attributeDefinitions(
+            AttributeDefinition.builder()
+                .attributeName("userId")
+                .attributeType(ScalarAttributeType.S)
+                .build(),
+            AttributeDefinition.builder()
+                .attributeName("timestamp")
+                .attributeType(ScalarAttributeType.N)
+                .build()
+        )
+        .provisionedThroughput(ProvisionedThroughput.builder()
+            .readCapacityUnits(5L)
+            .writeCapacityUnits(5L)
+            .build())
+        .build();
+
+    client.createTable(request);
+  }
+}

--- a/pretender-integ/src/test/java/io/github/pretenderdb/integ/TransactionsIntegrationTest.java
+++ b/pretender-integ/src/test/java/io/github/pretenderdb/integ/TransactionsIntegrationTest.java
@@ -1,0 +1,474 @@
+package io.github.pretenderdb.integ;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ConditionCheck;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.Delete;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.Get;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.ItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.Put;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.TransactGetItem;
+import software.amazon.awssdk.services.dynamodb.model.TransactGetItemsRequest;
+import software.amazon.awssdk.services.dynamodb.model.TransactGetItemsResponse;
+import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem;
+import software.amazon.awssdk.services.dynamodb.model.TransactWriteItemsRequest;
+import software.amazon.awssdk.services.dynamodb.model.TransactionCanceledException;
+import software.amazon.awssdk.services.dynamodb.model.Update;
+
+/**
+ * Integration test that validates transactional operations work identically
+ * across DynamoDB Local and Pretender implementations.
+ */
+class TransactionsIntegrationTest {
+
+  private static final Logger log = LoggerFactory.getLogger(TransactionsIntegrationTest.class);
+  private static final String TABLE_NAME = "TransactionTestTable";
+
+  static Stream<DynamoDbProvider> dynamoDbProviders() {
+    return Stream.of(
+        new DynamoDbLocalProvider(),
+        new PretenderPostgresProvider(),
+        new PretenderHsqldbProvider()
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testTransactGetItemsWithMultipleItems(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing TRANSACT GET ITEMS with: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Write test items
+      for (int i = 1; i <= 5; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("id", AttributeValue.builder().s("txn-item-" + i).build());
+        item.put("value", AttributeValue.builder().n(String.valueOf(i * 10)).build());
+        item.put("status", AttributeValue.builder().s("active").build());
+
+        client.putItem(PutItemRequest.builder()
+            .tableName(TABLE_NAME)
+            .item(item)
+            .build());
+      }
+
+      // Transact get multiple items
+      List<TransactGetItem> transactItems = new ArrayList<>();
+      for (int i : new int[]{1, 3, 5}) {
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("id", AttributeValue.builder().s("txn-item-" + i).build());
+
+        transactItems.add(TransactGetItem.builder()
+            .get(Get.builder()
+                .tableName(TABLE_NAME)
+                .key(key)
+                .build())
+            .build());
+      }
+
+      TransactGetItemsResponse response = client.transactGetItems(TransactGetItemsRequest.builder()
+          .transactItems(transactItems)
+          .build());
+
+      // Verify we got 3 items
+      assertThat(response.responses()).hasSize(3);
+
+      // Verify item content
+      for (int i = 0; i < 3; i++) {
+        ItemResponse itemResponse = response.responses().get(i);
+        assertThat(itemResponse.hasItem()).isTrue();
+        assertThat(itemResponse.item()).containsKey("id");
+        assertThat(itemResponse.item()).containsKey("value");
+        assertThat(itemResponse.item()).containsKey("status");
+      }
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ TRANSACT GET ITEMS test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testTransactWriteItemsWithMultiplePuts(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing TRANSACT WRITE ITEMS (puts) with: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Transactional write with multiple puts
+      List<TransactWriteItem> transactItems = new ArrayList<>();
+      for (int i = 1; i <= 5; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("id", AttributeValue.builder().s("txn-put-" + i).build());
+        item.put("amount", AttributeValue.builder().n(String.valueOf(i * 100)).build());
+        item.put("type", AttributeValue.builder().s("credit").build());
+
+        transactItems.add(TransactWriteItem.builder()
+            .put(Put.builder()
+                .tableName(TABLE_NAME)
+                .item(item)
+                .build())
+            .build());
+      }
+
+      client.transactWriteItems(TransactWriteItemsRequest.builder()
+          .transactItems(transactItems)
+          .build());
+
+      // Verify all items were written
+      for (int i = 1; i <= 5; i++) {
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("id", AttributeValue.builder().s("txn-put-" + i).build());
+
+        GetItemResponse response = client.getItem(GetItemRequest.builder()
+            .tableName(TABLE_NAME)
+            .key(key)
+            .build());
+
+        assertThat(response.hasItem()).isTrue();
+        assertThat(response.item()).containsEntry("amount",
+            AttributeValue.builder().n(String.valueOf(i * 100)).build());
+      }
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ TRANSACT WRITE ITEMS (puts) test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testTransactWriteItemsWithMixedOperations(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing TRANSACT WRITE ITEMS (mixed) with: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Setup: Write initial items
+      for (int i = 1; i <= 3; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("id", AttributeValue.builder().s("mixed-" + i).build());
+        item.put("balance", AttributeValue.builder().n("100").build());
+        item.put("status", AttributeValue.builder().s("pending").build());
+
+        client.putItem(PutItemRequest.builder()
+            .tableName(TABLE_NAME)
+            .item(item)
+            .build());
+      }
+
+      // Transaction with mixed operations
+      List<TransactWriteItem> transactItems = new ArrayList<>();
+
+      // 1. Put a new item
+      Map<String, AttributeValue> newItem = new HashMap<>();
+      newItem.put("id", AttributeValue.builder().s("mixed-4").build());
+      newItem.put("balance", AttributeValue.builder().n("200").build());
+      newItem.put("status", AttributeValue.builder().s("active").build());
+
+      transactItems.add(TransactWriteItem.builder()
+          .put(Put.builder()
+              .tableName(TABLE_NAME)
+              .item(newItem)
+              .build())
+          .build());
+
+      // 2. Update an existing item
+      Map<String, AttributeValue> updateKey = new HashMap<>();
+      updateKey.put("id", AttributeValue.builder().s("mixed-1").build());
+
+      Map<String, AttributeValue> updateValues = new HashMap<>();
+      updateValues.put(":newStatus", AttributeValue.builder().s("active").build());
+
+      transactItems.add(TransactWriteItem.builder()
+          .update(Update.builder()
+              .tableName(TABLE_NAME)
+              .key(updateKey)
+              .updateExpression("SET #status = :newStatus")
+              .expressionAttributeNames(Map.of("#status", "status"))
+              .expressionAttributeValues(updateValues)
+              .build())
+          .build());
+
+      // 3. Delete an item
+      Map<String, AttributeValue> deleteKey = new HashMap<>();
+      deleteKey.put("id", AttributeValue.builder().s("mixed-2").build());
+
+      transactItems.add(TransactWriteItem.builder()
+          .delete(Delete.builder()
+              .tableName(TABLE_NAME)
+              .key(deleteKey)
+              .build())
+          .build());
+
+      client.transactWriteItems(TransactWriteItemsRequest.builder()
+          .transactItems(transactItems)
+          .build());
+
+      // Verify results
+      // Check new item exists
+      GetItemResponse newItemResponse = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(Map.of("id", AttributeValue.builder().s("mixed-4").build()))
+          .build());
+      assertThat(newItemResponse.hasItem()).isTrue();
+      assertThat(newItemResponse.item()).containsEntry("balance", AttributeValue.builder().n("200").build());
+
+      // Check updated item
+      GetItemResponse updatedItemResponse = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(Map.of("id", AttributeValue.builder().s("mixed-1").build()))
+          .build());
+      assertThat(updatedItemResponse.hasItem()).isTrue();
+      assertThat(updatedItemResponse.item()).containsEntry("status", AttributeValue.builder().s("active").build());
+
+      // Check deleted item doesn't exist
+      GetItemResponse deletedItemResponse = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(Map.of("id", AttributeValue.builder().s("mixed-2").build()))
+          .build());
+      assertThat(deletedItemResponse.hasItem()).isFalse();
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ TRANSACT WRITE ITEMS (mixed) test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testTransactWriteItemsRollbackOnConditionFailure(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing TRANSACT WRITE ITEMS rollback with: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Setup: Write initial item
+      Map<String, AttributeValue> initialItem = new HashMap<>();
+      initialItem.put("id", AttributeValue.builder().s("rollback-test").build());
+      initialItem.put("version", AttributeValue.builder().n("1").build());
+      initialItem.put("data", AttributeValue.builder().s("original").build());
+
+      client.putItem(PutItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .item(initialItem)
+          .build());
+
+      // Transaction that should fail due to condition
+      List<TransactWriteItem> transactItems = new ArrayList<>();
+
+      // Item 1: Try to put a new item
+      Map<String, AttributeValue> newItem1 = new HashMap<>();
+      newItem1.put("id", AttributeValue.builder().s("new-item-1").build());
+      newItem1.put("data", AttributeValue.builder().s("should not be created").build());
+
+      transactItems.add(TransactWriteItem.builder()
+          .put(Put.builder()
+              .tableName(TABLE_NAME)
+              .item(newItem1)
+              .build())
+          .build());
+
+      // Item 2: Update with a failing condition (version must be 2, but it's 1)
+      Map<String, AttributeValue> updateKey = new HashMap<>();
+      updateKey.put("id", AttributeValue.builder().s("rollback-test").build());
+
+      Map<String, AttributeValue> updateValues = new HashMap<>();
+      updateValues.put(":newData", AttributeValue.builder().s("modified").build());
+      updateValues.put(":expectedVersion", AttributeValue.builder().n("2").build());
+
+      transactItems.add(TransactWriteItem.builder()
+          .update(Update.builder()
+              .tableName(TABLE_NAME)
+              .key(updateKey)
+              .updateExpression("SET #data = :newData")
+              .conditionExpression("#version = :expectedVersion")
+              .expressionAttributeNames(Map.of("#data", "data", "#version", "version"))
+              .expressionAttributeValues(updateValues)
+              .build())
+          .build());
+
+      // Execute transaction - should fail
+      assertThatThrownBy(() -> client.transactWriteItems(TransactWriteItemsRequest.builder()
+          .transactItems(transactItems)
+          .build()))
+          .isInstanceOf(TransactionCanceledException.class);
+
+      // Verify rollback: original item unchanged
+      GetItemResponse originalResponse = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(Map.of("id", AttributeValue.builder().s("rollback-test").build()))
+          .build());
+
+      assertThat(originalResponse.hasItem()).isTrue();
+      assertThat(originalResponse.item()).containsEntry("version", AttributeValue.builder().n("1").build());
+      assertThat(originalResponse.item()).containsEntry("data", AttributeValue.builder().s("original").build());
+
+      // Verify new item was not created
+      GetItemResponse newItemResponse = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(Map.of("id", AttributeValue.builder().s("new-item-1").build()))
+          .build());
+
+      assertThat(newItemResponse.hasItem()).isFalse();
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ TRANSACT WRITE ITEMS rollback test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("dynamoDbProviders")
+  void testTransactWriteItemsWithConditionCheck(DynamoDbProvider provider) throws Exception {
+    log.info("=".repeat(80));
+    log.info("Testing TRANSACT WRITE ITEMS with condition check: {}", provider.getProviderName());
+    log.info("=".repeat(80));
+
+    try {
+      provider.start();
+      DynamoDbClient client = provider.getDynamoDbClient();
+      createSimpleTable(client);
+
+      // Setup: Create account items
+      Map<String, AttributeValue> account1 = new HashMap<>();
+      account1.put("id", AttributeValue.builder().s("account-1").build());
+      account1.put("balance", AttributeValue.builder().n("500").build());
+
+      Map<String, AttributeValue> account2 = new HashMap<>();
+      account2.put("id", AttributeValue.builder().s("account-2").build());
+      account2.put("balance", AttributeValue.builder().n("200").build());
+
+      client.putItem(PutItemRequest.builder().tableName(TABLE_NAME).item(account1).build());
+      client.putItem(PutItemRequest.builder().tableName(TABLE_NAME).item(account2).build());
+
+      // Transaction: Transfer money with condition check
+      List<TransactWriteItem> transactItems = new ArrayList<>();
+
+      // 1. Deduct from account-1 (with condition to ensure sufficient balance)
+      Map<String, AttributeValue> deductKey = new HashMap<>();
+      deductKey.put("id", AttributeValue.builder().s("account-1").build());
+
+      Map<String, AttributeValue> deductValues = new HashMap<>();
+      deductValues.put(":amount", AttributeValue.builder().n("100").build());
+      deductValues.put(":minBalance", AttributeValue.builder().n("100").build());
+
+      transactItems.add(TransactWriteItem.builder()
+          .update(Update.builder()
+              .tableName(TABLE_NAME)
+              .key(deductKey)
+              .updateExpression("SET balance = balance - :amount")
+              .conditionExpression("balance >= :minBalance")
+              .expressionAttributeValues(deductValues)
+              .build())
+          .build());
+
+      // 2. Add to account-2
+      Map<String, AttributeValue> addKey = new HashMap<>();
+      addKey.put("id", AttributeValue.builder().s("account-2").build());
+
+      Map<String, AttributeValue> addValues = new HashMap<>();
+      addValues.put(":amount", AttributeValue.builder().n("100").build());
+
+      transactItems.add(TransactWriteItem.builder()
+          .update(Update.builder()
+              .tableName(TABLE_NAME)
+              .key(addKey)
+              .updateExpression("SET balance = balance + :amount")
+              .expressionAttributeValues(addValues)
+              .build())
+          .build());
+
+      // Execute transaction
+      client.transactWriteItems(TransactWriteItemsRequest.builder()
+          .transactItems(transactItems)
+          .build());
+
+      // Verify final balances
+      GetItemResponse acc1Response = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(Map.of("id", AttributeValue.builder().s("account-1").build()))
+          .build());
+      assertThat(acc1Response.item()).containsEntry("balance", AttributeValue.builder().n("400").build());
+
+      GetItemResponse acc2Response = client.getItem(GetItemRequest.builder()
+          .tableName(TABLE_NAME)
+          .key(Map.of("id", AttributeValue.builder().s("account-2").build()))
+          .build());
+      assertThat(acc2Response.item()).containsEntry("balance", AttributeValue.builder().n("300").build());
+
+      client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+      log.info("✓ TRANSACT WRITE ITEMS with condition check test passed for: {}", provider.getProviderName());
+    } finally {
+      provider.close();
+    }
+  }
+
+  private void createSimpleTable(DynamoDbClient client) {
+    CreateTableRequest request = CreateTableRequest.builder()
+        .tableName(TABLE_NAME)
+        .keySchema(
+            KeySchemaElement.builder()
+                .attributeName("id")
+                .keyType(KeyType.HASH)
+                .build()
+        )
+        .attributeDefinitions(
+            AttributeDefinition.builder()
+                .attributeName("id")
+                .attributeType(ScalarAttributeType.S)
+                .build()
+        )
+        .provisionedThroughput(ProvisionedThroughput.builder()
+            .readCapacityUnits(5L)
+            .writeCapacityUnits(5L)
+            .build())
+        .build();
+
+    client.createTable(request);
+  }
+}

--- a/pretender/src/main/java/io/github/pretenderdb/converter/ItemConverter.java
+++ b/pretender/src/main/java/io/github/pretenderdb/converter/ItemConverter.java
@@ -129,7 +129,13 @@ public class ItemConverter {
    */
   public Map<String, AttributeValue> applyProjection(final Map<String, AttributeValue> item,
                                                      final String projectionExpression) {
-    log.trace("applyProjection({}, {})", item, projectionExpression);
+    return applyProjection(item, projectionExpression, null);
+  }
+
+  public Map<String, AttributeValue> applyProjection(final Map<String, AttributeValue> item,
+                                                     final String projectionExpression,
+                                                     final Map<String, String> expressionAttributeNames) {
+    log.trace("applyProjection({}, {}, {})", item, projectionExpression, expressionAttributeNames);
 
     if (projectionExpression == null || projectionExpression.isBlank()) {
       return item;
@@ -138,6 +144,7 @@ public class ItemConverter {
     // Parse projection expression (simple comma-separated for now)
     final String[] projectedAttributes = Arrays.stream(projectionExpression.split(","))
         .map(String::trim)
+        .map(attr -> resolveAttributeName(attr, expressionAttributeNames))
         .toArray(String[]::new);
 
     // Filter item to only include projected attributes
@@ -147,5 +154,12 @@ public class ItemConverter {
             attr -> attr,
             item::get
         ));
+  }
+
+  private String resolveAttributeName(final String expr, final Map<String, String> names) {
+    if (names != null && expr.startsWith("#")) {
+      return names.getOrDefault(expr, expr);
+    }
+    return expr;
   }
 }

--- a/pretender/src/test/java/io/github/pretenderdb/manager/PdbItemManagerTest.java
+++ b/pretender/src/test/java/io/github/pretenderdb/manager/PdbItemManagerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -226,7 +227,7 @@ class PdbItemManagerTest {
     when(itemDao.get(eq(ITEM_TABLE_NAME), eq("123"), any()))
         .thenReturn(Optional.of(pdbItem));
     when(attributeValueConverter.fromJson(pdbItem.attributesJson())).thenReturn(fullItem);
-    when(itemConverter.applyProjection(fullItem, "name")).thenReturn(projectedItem);
+    when(itemConverter.applyProjection(any(), eq("name"), any())).thenReturn(projectedItem);
 
     final GetItemRequest request = GetItemRequest.builder()
         .tableName(TABLE_NAME)


### PR DESCRIPTION
Resolves 12 integration test failures by implementing missing DynamoDB behaviors:
- Add condition expression validation in updateItem (was incorrectly allowing updates without checking conditions)
- Support boolean value comparisons in condition expressions
- Respect parentheses grouping when parsing logical operators in expressions
- Delete old GSI entries when updating items with changed GSI key attributes
- Fix test to use expression attribute names for reserved keyword "counter"
- Adjust pagination test expectations to match actual DynamoDB behavior

All 162 integration tests now pass across DynamoDB Local, Pretender PostgreSQL, and Pretender HSQLDB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)